### PR TITLE
Add babili flag to documentation and fix typo

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,7 @@ const argv = yargs
     type: 'boolean'
   })
   .option('babili', {
+    describe: 'Use babili minifier',
     type: 'boolean'
   })
   .version()
@@ -27,7 +28,7 @@ const argv = yargs
   .alias('help', 'h')
   .alias('version', 'v')
   .epilog('Size Limit will read size-limit section from package.json.\n' +
-          'Configurtion example:\n' +
+          'Configuration example:\n' +
           '\n' +
           '  "size-limit": [\n' +
           '    {\n' +


### PR DESCRIPTION
```sh
$ node cli --version # 0.8.0

$ node cli --help
cli

Options:
  --why, -w      Show package content                                  [boolean]
  --babili       Use babili minifier                                   [boolean]
  --version, -v  Show version number                                   [boolean]
  --help, -h     Show help                                             [boolean]

Size Limit will read size-limit section from package.json.
Configuration example:

  "size-limit": [
    {
      "path": "index.js",
      "limit": "9 KB",
      "babili": true
    }
  ]
```
