### PR TITLE
Support custom webpack.config.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -214,7 +214,11 @@ getOptions.then(files => {
         'Add Webpack Bundle Analyzer to your Webpack config.'
       )
     }
-    const opts = { bundle: file.bundle, webpack: file.webpack }
+    const opts = {
+      bundle: file.bundle,
+      webpack: file.webpack,
+      config: argv.config
+    }
     if (file.ignore) {
       opts.ignore = Object.keys(file.ignore)
     }

--- a/cli.js
+++ b/cli.js
@@ -269,9 +269,13 @@ getOptions.then(files => {
     return file
   })
 
-  process.stdout.write(
-    chalk.gray('  With all dependencies, minified and gzipped\n\n'))
-
+  let message
+  if (argv.config) {
+    message = '  With given webpack configuration\n\n'
+  } else {
+    message = '  With all dependencies, minified and gzipped\n\n'
+  }
+  process.stdout.write(chalk.gray(message))
   return checks
 }).then(files => {
   if (argv.why && files.length > 1) {

--- a/cli.js
+++ b/cli.js
@@ -39,7 +39,8 @@ const argv = yargs
           '    Show reasons why project have this size.\n' +
           '  $0 index.js\n' +
           '    Check specific file size with all file dependencies.\n' +
-          '\n' +
+          '  $0 --config my.custom.webpack.config.js\n' +
+          '    Override built-in webpack configuration with your own\n' +
           'Size Limit will read size-limit section from package.json.\n' +
           'Configuration example:\n' +
           EXAMPLE)

--- a/index.js
+++ b/index.js
@@ -155,7 +155,8 @@ function getSize (files, opts) {
         throw new Error(stats.toString('errors-only'))
       }
 
-      const name = `${ stats.compilation.outputOptions.filename }.gz`
+      let name = `${ stats.compilation.outputOptions.filename }`
+      name += opts.config ? '' : '.gz'
       const assets = stats.toJson().assets
       const size = assets.find(i => i.name === name).size
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ function projectName (opts, files) {
 }
 
 function getConfig (files, opts) {
+  if (opts.config) {
+  // eslint-disable-next-line global-require,security/detect-non-literal-require
+    return require(path.join(process.cwd(), opts.config))
+  }
+
   const config = {
     entry: files,
     output: {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -243,3 +243,10 @@ it('throws on --why with disabled webpack', () => {
     expect(result.code).toEqual(1)
   })
 })
+
+it('uses custom webpack when specified via --config', () => {
+  return run([], { cwd: fixture('config') }).then(result => {
+    expect(result.out).toContain('Package size: 65 B\n')
+    expect(result.code).toEqual(0)
+  })
+})

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -245,8 +245,9 @@ it('throws on --why with disabled webpack', () => {
 })
 
 it('uses custom webpack when specified via --config', () => {
-  return run([], { cwd: fixture('config') }).then(result => {
-    expect(result.out).toContain('Package size: 65 B\n')
+  return run(['--config', 'webpack.config.js'],
+    { cwd: fixture('config') }).then(result => {
+    expect(result.out).toContain('Package size: 2.38 KB')
     expect(result.code).toEqual(0)
   })
 })

--- a/test/fixtures/config/index.js
+++ b/test/fixtures/config/index.js
@@ -1,0 +1,13 @@
+'use strict'
+
+for (let i = 1; i <= 100; i++) {
+  if (i % 15 === 0) {
+    console.log('fizzbuzz')
+  } else if (i % 3 === 0) {
+    console.log('fizz')
+  } else if (i % 5 === 0) {
+    console.log('buzz')
+  } else {
+    console.log(i)
+  }
+}

--- a/test/fixtures/config/package.json
+++ b/test/fixtures/config/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "size-limit": [
+    { "path": "index.js" }
+  ]
+}

--- a/test/fixtures/config/webpack.config.js
+++ b/test/fixtures/config/webpack.config.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const path = require('path')
+
+module.exports = {
+  entry: path.join(__dirname, 'index.js'),
+  output: {
+    filename: path.join(__dirname, 'out.js')
+  }
+}

--- a/test/fixtures/config/webpack.config.js
+++ b/test/fixtures/config/webpack.config.js
@@ -5,6 +5,6 @@ const path = require('path')
 module.exports = {
   entry: path.join(__dirname, 'index.js'),
   output: {
-    filename: path.join(__dirname, 'out.js')
+    filename: 'out.js'
   }
 }


### PR DESCRIPTION
In attempt to address https://github.com/ai/size-limit/issues/16, I have implemented a new `--config` flag that takes a custom webpack config, and bundles the output with that instead of the one predefined [here](https://github.com/ai/size-limit/blob/master/index.js#L32-L78). Here is an example of the new functionality on a private repo of mine:

```
➜  demo git:(size) npm run size
npm info it worked if it ends with ok
npm info using npm@3.10.10
npm info using node@v6.11.2
npm info lifecycle demo@3.2.2~presize: demo@3.2.2
npm info lifecycle demo@3.2.2~size: demo@3.2.2

> demo@3.2.2 size /Users/smehta/github.com/SivanMehta/react-demo
> size-limit --config webpack.config.js


  Package size: 303.86 KB
  With given webpack configuration

npm info lifecycle demo@3.2.2~postsize: demo@3.2.2
npm info ok
```

I have also added this to my `package.json`:

```js
"size-limit": [
  { "path": "app/index.js" }
]
```

Any feedback is welcome, but I am specifically unclear on what error messages should be thrown (if any). In the spirit of what @ai said [here](https://github.com/ai/size-limit/issues/16#issuecomment-325080220), if you pass custom config, it could just be your responsibility.

Not sure why [the appveyors test are failing](https://ci.appveyor.com/project/ai/size-limit/build/1.0.75), as [this test](https://github.com/ai/size-limit/blob/master/test/index.test.js#L53-L57) seems to be passing locally and in Travis, but not in Appveyor. However, this seems to be consistent with a lot of other PRS already merged.