### PR TITLE
Remove Node.js 4 from Appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
     - nodejs_version: "9"
     - nodejs_version: "8"
     - nodejs_version: "6"
-    - nodejs_version: "4"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Node.js 4 was removed only for Travis in b7276b7e0e3cd154e6d3e3aeef4fc7d5c37d849d and is failing the Appveyor builds