### PR TITLE
Add correct latest stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 cache: yarn
 node_js:
-  - stable
+  - node
   - "8"
   - "6"


### PR DESCRIPTION
Some time ago `stable` was deprecated in favor of `node` identifier