### PR TITLE
Distinct minified and gziped empty sizes

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ const os = require('os')
 
 const promisify = require('./promisify')
 
-const WEBPACK_EMPTY_PROJECT = 310
+const WEBPACK_EMPTY_PROJECT = {
+  minified: 577,
+  gziped: 310
+}
 
 const STATIC =
   /\.(eot|woff2?|ttf|otf|svg|png|jpe?g|gif|webp|mp4|mp3|ogg|pdf|html|ico)$/
@@ -187,7 +190,14 @@ function getSize (files, opts) {
         size = extractSize(stats, opts)
       }
 
-      return size - WEBPACK_EMPTY_PROJECT
+      let emptySize
+      if (opts.config || opts.gzip === false) {
+        emptySize = WEBPACK_EMPTY_PROJECT.minified
+      } else {
+        emptySize = WEBPACK_EMPTY_PROJECT.gziped
+      }
+
+      return size - emptySize
     })
   }
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -175,21 +175,21 @@ it('shows limit', () => {
 
 it('supports glob patterns', () => {
   return run([], { cwd: fixture('glob') }).then(result => {
-    expect(result.out).toContain('19 B\n')
+    expect(result.out).toContain('Package size: 19 B\n')
     expect(result.code).toEqual(0)
   })
 })
 
 it('supports ES2016', () => {
   return run([], { cwd: fixture('es2016') }).then(result => {
-    expect(result.out).toContain('34 B\n')
+    expect(result.out).toContain('Package size: 34 B\n')
     expect(result.code).toEqual(0)
   })
 })
 
 it('supports multiple files', () => {
   return run([], { cwd: fixture('multiple') }).then(result => {
-    expect(result.out).toContain('25 B\n')
+    expect(result.out).toContain('Package size: 25 B\n')
     expect(result.code).toEqual(0)
   })
 })
@@ -244,7 +244,7 @@ it('returns size', () => {
 
 it('uses different units', () => {
   return run(['test/fixtures/bad/index.js']).then(result => {
-    expect(result.out).toContain('2.2 KB\n')
+    expect(result.out).toContain('Package size: 2.2 KB\n')
     expect(result.code).toEqual(0)
   })
 })
@@ -252,42 +252,42 @@ it('uses different units', () => {
 it('supports absolute path', () => {
   const file = path.join(__dirname, 'fixtures/unlimit/empty.js')
   return run([file]).then(result => {
-    expect(result.out).toContain('0 B\n')
+    expect(result.out).toContain('Package size: 0 B\n')
     expect(result.code).toEqual(0)
   })
 })
 
 it('ignores peerDependencies', () => {
   return run([], { cwd: fixture('peer') }).then(result => {
-    expect(result.out).toContain('97 B\n')
+    expect(result.out).toContain('Package size: 97 B\n')
     expect(result.code).toEqual(0)
   })
 })
 
 it('disables webpack by argument', () => {
   return run(['--no-webpack', 'test/fixtures/bad/index.js']).then(result => {
-    expect(result.out).toContain('51 B\n')
+    expect(result.out).toContain('Package size: 51 B\n')
     expect(result.code).toEqual(0)
   })
 })
 
 it('disables webpack by option', () => {
   return run([], { cwd: fixture('bundled') }).then(result => {
-    expect(result.out).toContain('51 B\n')
+    expect(result.out).toContain('Package size: 51 B\n')
     expect(result.code).toEqual(0)
   })
 })
 
 it('disables gzip by argument', () => {
   return run(['--no-gzip', 'test/fixtures/bad/index.js']).then(result => {
-    expect(result.out).toContain('6.52 KB\n')
+    expect(result.out).toContain('Package size: 6.26 KB\n')
     expect(result.code).toEqual(0)
   })
 })
 
 it('disables gzip by option', () => {
   return run([], { cwd: fixture('gzip') }).then(result => {
-    expect(result.out).toContain('296 B\n')
+    expect(result.out).toContain('Package size: 29 B\n')
     expect(result.code).toEqual(0)
   })
 })
@@ -301,7 +301,7 @@ it('throws on --why with disabled webpack', () => {
 
 it('uses custom webpack', () => {
   return run([], { cwd: fixture('webpack-config') }).then(result => {
-    expect(result.out).toContain('Package size: 2.55 KB')
+    expect(result.out).toContain('Package size: 2.29 KB')
     expect(result.code).toEqual(0)
   })
 })
@@ -311,7 +311,7 @@ it('uses custom webpack when specified via --config', () => {
     '--config', fixture('webpack-config/webpack.config.js'),
     fixture('webpack-config/index.js')
   ]).then(result => {
-    expect(result.out).toContain('Package size: 2.72 KB')
+    expect(result.out).toContain('Package size: 2.46 KB')
     expect(result.code).toEqual(0)
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,13 @@ function trim (num) {
   return Math.floor(num / 10) * 10
 }
 
-it('returns 0 for empty project', () => {
+it('returns 0 for minified empty project', () => {
+  return getSize(fixture('unlimit/empty'), { gzip: false }).then(size => {
+    expect(size).toEqual(0)
+  })
+})
+
+it('returns 0 for gziped empty project', () => {
   return getSize(fixture('unlimit/empty')).then(size => {
     expect(size).toEqual(0)
   })
@@ -80,7 +86,7 @@ it('disables webpack on request', () => {
 
 it('disables gzip on request', () => {
   return getSize([fixture('bad/index')], { gzip: false }).then(size => {
-    expect(size).toEqual(6674)
+    expect(size).toEqual(6407)
   })
 })
 
@@ -96,6 +102,6 @@ it('uses custom webpack config', () => {
   return getSize(fixture('webpack-config/index'), {
     config: fixture('webpack-config/webpack.config')
   }).then(size => {
-    expect(size).toEqual(2790)
+    expect(size).toEqual(2523)
   })
 })


### PR DESCRIPTION
Currently not gziped empty projects shows 267 bytes. It's because you used only one constant for this.