### PR TITLE
Remove duplicated uglify and define plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const Analyzer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const MemoryFS = require('memory-fs')
 const gzipSize = require('gzip-size')
 const webpack = require('webpack')
-const Uglify = require('uglifyjs-webpack-plugin')
 const path = require('path')
 const fs = require('fs')
 const os = require('os')
@@ -86,12 +85,7 @@ function getConfig (files, opts) {
         }
       ]
     },
-    plugins: [
-      new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify('production')
-      }),
-      new Uglify({ sourceMap: false })
-    ]
+    plugins: []
   }
 
   if (opts.gzip !== false) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "memory-fs": "^0.4.1",
     "read-pkg-up": "^3.0.0",
     "style-loader": "^0.20.2",
-    "uglifyjs-webpack-plugin": "^1.2.2",
     "webpack": "^4.0.1",
     "webpack-bundle-analyzer": "^2.11.1",
     "yargs": "^11.0.0"

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -196,7 +196,7 @@ it('supports multiple files', () => {
 
 it('checks limits', () => {
   return run([], { cwd: fixture('bad') }).then(result => {
-    expect(result.out).toContain('exceeded by 204 B')
+    expect(result.out).toContain('exceeded by 234 B')
     expect(result.code).toEqual(3)
   })
 })
@@ -244,7 +244,7 @@ it('returns size', () => {
 
 it('uses different units', () => {
   return run(['test/fixtures/bad/index.js']).then(result => {
-    expect(result.out).toContain('Package size: 2.2 KB\n')
+    expect(result.out).toContain('Package size: 2.23 KB\n')
     expect(result.code).toEqual(0)
   })
 })
@@ -280,7 +280,7 @@ it('disables webpack by option', () => {
 
 it('disables gzip by argument', () => {
   return run(['--no-gzip', 'test/fixtures/bad/index.js']).then(result => {
-    expect(result.out).toContain('Package size: 6.26 KB\n')
+    expect(result.out).toContain('Package size: 6.31 KB\n')
     expect(result.code).toEqual(0)
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,13 +24,13 @@ it('returns 0 for gziped empty project', () => {
 
 it('shows project size', () => {
   return getSize(fixture('bad/index')).then(size => {
-    expect(size).toEqual(2252)
+    expect(size).toEqual(2282)
   })
 })
 
 it('accepts array', () => {
   return getSize([fixture('bad/index'), fixture('good/index')]).then(size => {
-    expect(size).toEqual(2267)
+    expect(size).toEqual(2296)
   })
 })
 
@@ -54,7 +54,7 @@ it('support images', () => {
 
 it('supports CSS', () => {
   return getSize(fixture('css/index')).then(size => {
-    expect(trim(size)).toEqual(2320)
+    expect(trim(size)).toEqual(2330)
   })
 })
 
@@ -86,7 +86,7 @@ it('disables webpack on request', () => {
 
 it('disables gzip on request', () => {
   return getSize([fixture('bad/index')], { gzip: false }).then(size => {
-    expect(size).toEqual(6407)
+    expect(size).toEqual(6462)
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5619,7 +5619,7 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uglifyjs-webpack-plugin@^1.1.1, uglifyjs-webpack-plugin@^1.2.2:
+uglifyjs-webpack-plugin@^1.1.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.2.tgz#e7516d4367afdb715c3847841eb46f94c45ca2b9"
   dependencies:


### PR DESCRIPTION
Current results are a kind of lie since uglify is applied twice. Webpack by default adds uglify and define plugin with `production` string