### PR TITLE
Return from getSize both bundle and gzip results

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ const index = path.join(__dirname, 'index.js')
 const extra = path.join(__dirname, 'extra.js')
 
 getSize([index, extra]).then(size => {
-  if (size > 1 * 1024 * 1024) {
+  if (size.gzip > 1 * 1024 * 1024) {
     console.error('Project is now larger than 1MB!')
   }
 })

--- a/cli.js
+++ b/cli.js
@@ -289,7 +289,11 @@ getOptions.then(files => {
       opts.analyzer = process.env['NODE_ENV'] === 'test' ? 'static' : 'server'
     }
     return getSize(file.full, opts).then(size => {
-      file.size = size
+      if (typeof size.gzip === 'number') {
+        file.size = size.gzip
+      } else {
+        file.size = size.bundle
+      }
       return file
     })
   }))

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,27 +10,21 @@ function trim (num) {
   return Math.floor(num / 10) * 10
 }
 
-it('returns 0 for minified empty project', () => {
-  return getSize(fixture('unlimit/empty'), { gzip: false }).then(size => {
-    expect(size).toEqual(0)
-  })
-})
-
-it('returns 0 for gziped empty project', () => {
+it('returns 0 for bundle and gzip empty project', () => {
   return getSize(fixture('unlimit/empty')).then(size => {
-    expect(size).toEqual(0)
+    expect(size).toEqual({ bundle: 0, gzip: 0 })
   })
 })
 
-it('shows project size', () => {
+it('shows project bundle and gzip sizes', () => {
   return getSize(fixture('bad/index')).then(size => {
-    expect(size).toEqual(2282)
+    expect(size).toEqual({ bundle: 6462, gzip: 2282 })
   })
 })
 
 it('accepts array', () => {
   return getSize([fixture('bad/index'), fixture('good/index')]).then(size => {
-    expect(size).toEqual(2296)
+    expect(size).toEqual({ bundle: 6512, gzip: 2296 })
   })
 })
 
@@ -42,37 +36,37 @@ it('returns error', () => {
 
 it('supports ES2016', () => {
   return getSize(fixture('es2016/index')).then(size => {
-    expect(size).toEqual(34)
+    expect(size).toEqual({ bundle: 47, gzip: 34 })
   })
 })
 
 it('support images', () => {
   return getSize(fixture('img/index')).then(size => {
-    expect(size).toEqual(53)
+    expect(size).toEqual({ bundle: 89, gzip: 53 })
   })
 })
 
 it('supports CSS', () => {
   return getSize(fixture('css/index')).then(size => {
-    expect(trim(size)).toEqual(2330)
+    expect(trim(size.gzip)).toEqual(2330)
   })
 })
 
 it('supports CSS modules', () => {
   return getSize(fixture('cssmodules/index')).then(size => {
-    expect(trim(size)).toEqual(2360)
+    expect(trim(size.gzip)).toEqual(2360)
   })
 })
 
 it('removes non-production code', () => {
   return getSize(fixture('multiple/production')).then(size => {
-    expect(size).toEqual(8)
+    expect(size).toEqual({ bundle: 14, gzip: 8 })
   })
 })
 
 it('ignores dependencies on request', () => {
   return getSize(fixture('peer/index'), { ignore: ['redux'] }).then(size => {
-    expect(size).toEqual(97)
+    expect(size).toEqual({ bundle: 222, gzip: 97 })
   })
 })
 
@@ -80,13 +74,13 @@ it('disables webpack on request', () => {
   return getSize([
     fixture('bad/index'), fixture('es2016/index')
   ], { webpack: false }).then(size => {
-    expect(size).toEqual(122)
+    expect(size).toEqual({ bundle: 82, gzip: 122 })
   })
 })
 
 it('disables gzip on request', () => {
   return getSize([fixture('bad/index')], { gzip: false }).then(size => {
-    expect(size).toEqual(6462)
+    expect(size).toEqual({ bundle: 6462 })
   })
 })
 
@@ -94,7 +88,7 @@ it('disables gzip and webpack on request', () => {
   return getSize([
     fixture('bad/index')
   ], { webpack: false, gzip: false }).then(size => {
-    expect(size).toEqual(31)
+    expect(size).toEqual({ bundle: 31 })
   })
 })
 
@@ -102,6 +96,6 @@ it('uses custom webpack config', () => {
   return getSize(fixture('webpack-config/index'), {
     config: fixture('webpack-config/webpack.config')
   }).then(size => {
-    expect(size).toEqual(2523)
+    expect(size).toEqual({ bundle: 2523 })
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,8 @@ function fixture (name) {
 }
 
 function trim (num) {
-  return Math.floor(num / 10) * 10
+  // round number with assumption
+  return Math.floor(num / 20) * 20
 }
 
 it('returns 0 for bundle and gzip empty project', () => {
@@ -48,7 +49,7 @@ it('support images', () => {
 
 it('supports CSS', () => {
   return getSize(fixture('css/index')).then(size => {
-    expect(trim(size.gzip)).toEqual(2330)
+    expect(trim(size.gzip)).toEqual(2320)
   })
 })
 


### PR DESCRIPTION
In my opinion both bundle and gzip results are important since there is also a cost of javascript parsing. This will let to bundle the code only once and have more pretty result. Currently I got this
```
  esm/index.js
  Package size: 29.8 KB

  esm/index.js
  Package size: 9.34 KB
  Size limit:   9.4 KB
```
In the next PR I'm gonna improve render in cli