### PR TITLE
Refactor render and fix array path output

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -173,6 +173,21 @@ it('shows limit', () => {
   })
 })
 
+it('accepts array for path', () => {
+  return run([], { cwd: fixture('array-path') }).then(result => {
+    expect(result.out).toEqual('\n' +
+    '  index1.js\n' +
+    '  Package size: 13 B\n' +
+    '\n' +
+    '  index1.js, index2.js\n' +
+    '  Package size: 22 B\n' +
+    '\n' +
+    '  With all dependencies, minified and gzipped\n' +
+    '\n')
+    expect(result.code).toEqual(0)
+  })
+})
+
 it('supports glob patterns', () => {
   return run([], { cwd: fixture('glob') }).then(result => {
     expect(result.out).toContain('Package size: 19 B\n')

--- a/test/fixtures/array-path/index1.js
+++ b/test/fixtures/array-path/index1.js
@@ -1,0 +1,1 @@
+console.log('index1')

--- a/test/fixtures/array-path/index2.js
+++ b/test/fixtures/array-path/index2.js
@@ -1,0 +1,1 @@
+console.log('index2')

--- a/test/fixtures/array-path/package.json
+++ b/test/fixtures/array-path/package.json
@@ -1,0 +1,10 @@
+{
+  "size-limit": [
+    {
+      "path": "index1.js"
+    },
+    {
+      "path": ["index1.js", "index2.js"]
+    }
+  ]
+}


### PR DESCRIPTION
- moved size renderer into pure function
- fixed `index1.js,index2.js` size name because of implicit casting array to string (types are really good here)
- removed a few unused props (and here)
- merged a few `then` chains because async operations are not required between them
- prevented parsing number with `bytes.parse` (and here)