### PR TITLE
Allow the usage of dynamic configuration

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -176,7 +176,8 @@ function getConfig () {
   const explorer = cosmiconfig('size-limit', {
     searchPlaces: [
       'package.json',
-      '.size-limit'
+      '.size-limit',
+      'size-limit.config.js'
     ]
   })
   return explorer


### PR DESCRIPTION
Next.js 6 now generates a vendor bundle with a dynamic filename. I'm looking for a way to handle this change. If you are happy with this change, I can update the documentation.
https://github.com/davidtheclark/cosmiconfig#searchplaces