### PR TITLE
Add a tip about CSS files' size calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,9 @@ In this case you can disable internal webpack:
  ],
 ```
 
-Also you should disable `webpack` option when you use Size Limit for tracking 
-size of CSS files. Otherwise you will get wrong numbers, because webpack inserts 
-`style-loader` runtime into the bundle, and this loader adds ≈2 KB 
-to the calculated size.
+If you use Size Limit to track size of CSS files only, you should set `webpack: false`.
+Otherwise you will get wrong numbers, because webpack inserts `style-loader` runtime 
+into the bundle, and this loader adds ≈2 KB to the calculated size.
 
 
 ## JavaScript API

--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ In this case you can disable internal webpack:
  ],
 ```
 
+Also you should disable `webpack` option when you use Size Limit for tracking 
+size of CSS files. Otherwise you will get wrong numbers, because webpack inserts 
+`style-loader` runtime into the bundle, and this loader adds ≈2 KB 
+to the calculated size.
+
 
 ## JavaScript API
 


### PR DESCRIPTION
Fixes #85.

Anyway, @ai, do you know, maybe there is a way to subtract size of style-loader or even don't add it to the bundle? It looks like an annoying side effect that shouldn't exist in a such library.