### PR TITLE
Greedy ignore pattern, fixes #121

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+let escapeRegexp = require('escape-string-regexp')
 let OptimizeCss = require('optimize-css-assets-webpack-plugin')
 let Compression = require('compression-webpack-plugin')
 let Analyzer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
@@ -98,8 +99,10 @@ function getConfig (files, opts) {
   }
 
   if (opts.ignore && opts.ignore.length !== 0) {
+    let escaped = opts.ignore.map(i => escapeRegexp(i))
+    let ignorePattern = new RegExp(`^(${ escaped.join('|') })($|/)`)
     config.externals = (context, request, callback) => {
-      if (opts.ignore.some(i => request.startsWith(i))) {
+      if (ignorePattern.test(request)) {
         callback(null, 'root a')
       } else {
         callback()

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cosmiconfig": "^5.2.1",
     "css-loader": "^3.0.0",
     "del": "^4.1.1",
+    "escape-string-regexp": "^2.0.0",
     "estimo": "^0.1.9",
     "file-loader": "^4.0.0",
     "globby": "^9.2.0",
@@ -59,6 +60,7 @@
     "jest": "^24.8.0",
     "lint-staged": "^8.2.0",
     "redux": "^4.0.1",
+    "redux-thunk": "^2.3.0",
     "yaspeller-ci": "^1.0.1"
   },
   "scripts": {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -318,7 +318,7 @@ it('supports absolute path', async () => {
 
 it('ignores peerDependencies', async () => {
   let { out, code } = await run([], { cwd: fixture('peer') })
-  expect(out).toContain('Package size: 9 B')
+  expect(out).toContain('Package size: 105 B')
   expect(code).toEqual(0)
 })
 

--- a/test/fixtures/peer/index.js
+++ b/test/fixtures/peer/index.js
@@ -1,3 +1,4 @@
 require('redux')
+require('redux-thunk')
 require('redux/lib/redux')
 require('@storeon/crosstab')

--- a/test/fixtures/peer/package.json
+++ b/test/fixtures/peer/package.json
@@ -4,6 +4,9 @@
     "redux": "*",
     "@storeon/crosstab": "*"
   },
+  "dependencies": {
+    "redux-thunk": "*"
+  },
   "size-limit": [
     {
       "path": "index.js",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,7 +87,7 @@ it('ignores dependencies on request', async () => {
   let size = await getSize(fixture('peer/index'), {
     ignore: ['redux', '@storeon/crosstab']
   })
-  expect(size.parsed).toEqual(43)
+  expect(size.parsed).toEqual(274)
 })
 
 it('disables webpack on request', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,6 +2300,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escodegen@^1.9.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
@@ -6172,6 +6177,11 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
 redux@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Addresses the problem raised in #121 - having `react` as `peerDep` would add any `react-*` packages to the ignore list, which is almost all packages :)

## Fix
Restore old RegExp based check, keeping the new `externalize` behavior

## Testing
I've added `redux-thunk`, as long it matches the problem, and configured test to handle it.