### PR TITLE
Control over webpack ModuleConcatenationPlugin, fixes #117

### DIFF
--- a/cli-body.js
+++ b/cli-body.js
@@ -467,6 +467,7 @@ async function run () {
       analyzer: process.env['NODE_ENV'] === 'test' ? 'static' : 'server',
       bundle: config.bundle,
       output: argv.saveBundle,
+      disableModuleConcatenation: true,
       ignore
     }
     let full = files.reduce((all, i) => all.concat(i.full), [])

--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ function getConfig (files, opts) {
       filename: projectName(opts, files),
       path: getBundlePath(opts)
     },
+    optimization: {
+      concatenateModules: !opts.disableModuleConcatenation
+    },
     module: {
       rules: [
         {
@@ -196,6 +199,8 @@ function getLoadingTime (size) {
  * @param {string} [opts.config] A path to custom webpack config.
  * @param {string} [opts.bundle] Bundle name for Analyzer mode.
  * @param {string} [opts.output] A path for output bundle.
+ * @param {boolean} [opts.disableModuleConcatenation=false] Module concatenation
+ *                                                          optimization
  * @param {string[]} [opts.ignore] Dependencies to be ignored.
  * @param {string|string[]} [opts.entry] Webpack entry to check the size.
  *


### PR DESCRIPTION
Without this option `--why` is almost useless for tree-shakable (and thus _concatenatable_) modules - see #117.
In the same time - disabling concatenation greatly affect result bundle size, thus it should be optional.

### Before
<img width="1099" alt="Screen Shot 2019-06-13 at 1 58 05 pm" src="https://user-images.githubusercontent.com/582410/59505138-e7db2880-8ee7-11e9-8876-1b4e0a69cc10.png">

### Afrer
<img width="1095" alt="Screen Shot 2019-06-13 at 1 57 41 pm" src="https://user-images.githubusercontent.com/582410/59505139-e7db2880-8ee7-11e9-8025-fbe696d3dfba.png">

### How
- Added a new CLI option
- Added a new API option with _reversed_ sense, to keep all existing customers untouched.

### Tests
It will require the usage of ESM. While this could be a good thing to test, I am not ready to do it as my first-time contribution - I've tested manually.