### PR TITLE
Getting plugins from local node_modules

### DIFF
--- a/packages/size-limit/load-plugins.js
+++ b/packages/size-limit/load-plugins.js
@@ -8,7 +8,9 @@ module.exports = function loadPlugins (pkg) {
   let list = toArray(pkg.package.dependencies)
     .concat(toArray(pkg.package.devDependencies))
     .filter(i => i.startsWith('@size-limit/'))
-    .reduce((all, i) => all.concat(require(require.resolve(i, { paths: [process.cwd()] }))), [])
+    .reduce((all, i) => all.concat(require(require.resolve(i, {
+      paths: [process.cwd()]
+    }))), [])
 
   return {
     list,

--- a/packages/size-limit/load-plugins.js
+++ b/packages/size-limit/load-plugins.js
@@ -8,7 +8,7 @@ module.exports = function loadPlugins (pkg) {
   let list = toArray(pkg.package.dependencies)
     .concat(toArray(pkg.package.devDependencies))
     .filter(i => i.startsWith('@size-limit/'))
-    .reduce((all, i) => all.concat(require(i)), [])
+    .reduce((all, i) => all.concat(require(require.resolve(i, { paths: [process.cwd()] }))), [])
 
   return {
     list,


### PR DESCRIPTION
Presets are looked for starting from the current folder (the current working directory of the process) and going down to the root to be sure of primary using the ones from local `node_modules`.