### PR TITLE
Allow to specify chrome executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,10 @@ Each section in the config can have these options:
 * **ignore**: an array of files and dependencies to exclude from
   the project size calculation.
 
+Plugin for execution time calculation uses chromium inside.
+If you are using it on CI, you may want to specify your custom chromium binary.
+It's available under `CHROME_EXECUTABLE_PATH` environment variable.
+
 If you use Size Limit to track the size of CSS files, make sure to set
 `webpack: false`. Otherwise, you will get wrong numbers, because webpack
 inserts `style-loader` runtime (≈2 KB) into the bundle.

--- a/packages/time/get-running-time.js
+++ b/packages/time/get-running-time.js
@@ -7,6 +7,11 @@ const EXAMPLE_TIME = 0.086 // Xiaomi Redmi 2, Snapdragon 410
 const URL = 'https://discuss.circleci.com/t/puppeteer-fails-on-circleci/22650'
 const JS_FILES = /\.m?js$/i
 
+const chromeExecutablePath = process.env.CHROME_EXECUTABLE_PATH
+
+const estimoOptions =
+  chromeExecutablePath ? { executablePath: chromeExecutablePath } : {}
+
 async function getTime (file, throttling = 1) {
   if (process.env.SIZE_LIMIT_FAKE_TIME) {
     return throttling * parseFloat(process.env.SIZE_LIMIT_FAKE_TIME)
@@ -15,7 +20,7 @@ async function getTime (file, throttling = 1) {
   for (let i = 0; i < 3; i++) {
     let perf
     try {
-      perf = await estimo(file)
+      perf = await estimo(file, estimoOptions)
     } catch (e) {
       if (process.env.CI) {
         console.warn(


### PR DESCRIPTION
As for now I have no option to specify chrome executable to use in @size-limit/time plugin. It causes problems for me in CI, because I'm unable to get it up and running on Node Alpine image.

It uses estimo, which uses puppeteer-core (not original puppeteer) inside, so it is not affected by PUPPETEER_* env variables. But as I found out, it passes options down to it.

That said I suggest to introduce CHROME_EXECUTABLE_PATH environment variable. I was also thinking to reuse PUPPETEER_EXECUTABLE_PATH env, but maybe it breaks incapsulation a bit, since we know you are using puppeteer inside.
I don't know how to test is locally for now. So I haven't verified it is working, but maybe you can publish some beta version in order to test it.