### PR TITLE
CLI message: use a plural form of the verb "contain" 

### DIFF
--- a/packages/size-limit/create-help.js
+++ b/packages/size-limit/create-help.js
@@ -97,7 +97,7 @@ module.exports = process => {
     let { rm } = npmCommands(pkg)
     printError(
       chalk.bgYellow.black(' WARN ') + ' You can remove size-limit dependency',
-      '       All plugins and presets already contains it as own dependency',
+      '       All plugins and presets already contain it as own dependency',
       '       ' + y(rm + 'size-limit'),
       ''
     )

--- a/packages/size-limit/test/__snapshots__/run.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/run.test.js.snap
@@ -208,7 +208,7 @@ You can remove size-limit dependency: [33myarn remove size-limit[39m
 
 exports[`shows size-limit dependency warning 1`] = `
 "[43m[30m WARN [39m[49m You can remove size-limit dependency
-       All plugins and presets already contains it as own dependency
+       All plugins and presets already contain it as own dependency
        [33mnpm remove size-limit[39m
 
 "


### PR DESCRIPTION
Just a small spelling fix:
> All plugins and presets already **contain** it as own dependency

I was actually thinking about a more informative message:
> As of __<version_number>__ having `size-limit` as a dependency is no longer required.
> You can safely remove it from your package.json since all plugins and presets already contain it as a dependency.
> Read more: https://github.com/ai/size-limit#usage

Let me know what you think.
