### PR TITLE
Fix MaxListenersExceededWarning

### DIFF
--- a/packages/size-limit/calc.js
+++ b/packages/size-limit/calc.js
@@ -2,6 +2,7 @@ module.exports = async function calc (plugins, config) {
   async function exec (step) {
     for (let plugin of plugins.list) {
       if (plugin[step]) {
+        process.setMaxListeners(config.checks.length)
         await Promise.all(config.checks.map(i => plugin[step](config, i)))
       }
     }


### PR DESCRIPTION
When size-limit checks the size for 16 files, these warnings appear in the log (on the local machine and CI)

```
yarn run v1.19.2
$ yarn size-limit
$ /home/circleci/size-limit-test/node_modules/.bin/size-limit
(node:99) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(node:99) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(node:99) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTERM listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(node:99) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGHUP listeners added to [process]. Use emitter.setMaxListeners() to increase limit
```

before:
https://circleci.com/gh/pustovalov/size-limit-test/2

after:
https://circleci.com/gh/pustovalov/size-limit-test/4

demo project:
https://github.com/pustovalov/size-limit-test