### PR TITLE
Fix spec when running on macOS

### DIFF
--- a/packages/size-limit/test/run.test.js
+++ b/packages/size-limit/test/run.test.js
@@ -62,6 +62,7 @@ function createProcess (cwd, args = []) {
 
 function clean (output) {
   return output
+    .replace(/var\/folders\/(.*)\//g, 'tmp/')
     .replace(/"cwd": "[^"]+"/, '"cwd": "/tmp/"')
     .replace(/"webpackOutput": "[^"]+"/, '"webpackOutput": "/tmp/"')
 }


### PR DESCRIPTION
Reference to: https://github.com/ai/size-limit/issues/164

Regex demo: https://regex101.com/r/mr7kpc/1

before:
```
[~/size-limit]$ yarn test                                                                                                                                           *[pp-macos-specs][ruby-2.6.1]
yarn run v1.22.4
$ jest-ci --coverage --forceExit && eslint-ci . && yarn spell
 PASS  packages/size-limit/test/bin.test.js
 PASS  packages/time/test/index.test.js
 PASS  packages/size-limit/test/size-limit-error.test.js
 PASS  packages/file/test/index.test.js
 PASS  packages/time/test/cache.test.js
 PASS  packages/size-limit/test/create-reporter.test.js
 PASS  packages/time/test/ci.test.js
 PASS  packages/dual-publish/test/index.test.js
 PASS  packages/size-limit/test/get-config.test.js
 PASS  packages/size-limit/test/index.test.js
 PASS  packages/webpack/test/index.test.js (5.686s)
 FAIL  packages/size-limit/test/run.test.js (5.972s)
  ● shows debug

    expect(received).toMatchSnapshot()

    Snapshot name: `shows debug 1`

    - Snapshot  - 2
    + Received  + 2

    @@ -15,11 +15,11 @@
                "index": [
                  "/packages/size-limit/test/fixtures/integration/index.js"
                ]
              },
              "output": {
    -           "path": "/tmp/"
    +           "path": "/var/folders/kj/w787fzx160130jtykf3kj1440000gn/T/"
              },
              "optimization": {
                "concatenateModules": true
              },
              "resolve": {
    @@ -91,11 +91,11 @@
                  "deleteAssetsMap": {}
                }
              ]
            },
            "bundles": [
    -         "/tmp/index.js"
    +         "/var/folders/kj/w787fzx160130jtykf3kj1440000gn/T/index.js"
            ],
            "size": 31,
            "loadTime": 0.01,
            "runTime": 1,
            "time": 1.01,

      255 |
      256 | it('shows debug', async () => {
    > 257 |   expect(clean(await check('integration', ['--debug']))).toMatchSnapshot()
          |                                                          ^
      258 | })
      259 |
      260 | it('shows debug on error', async () => {

      at Object.<anonymous> (packages/size-limit/test/run.test.js:257:58)

 › 1 snapshot failed.
 FAIL  packages/time/test/get-running-time.test.js (6.127s)
  ● calculates running time

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:

      14 | })
      15 |
    > 16 | it('calculates running time', async () => {
         | ^
      17 |   let runTime = await getRunningTime(EXAMPLE)
      18 |   expect(runTime).toBeGreaterThan(0.03)
      19 |   expect(runTime).toBeLessThan(0.2)

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Object.<anonymous> (packages/time/test/get-running-time.test.js:16:1)

Snapshot Summary
 › 1 snapshot failed from 1 test suite. Inspect your code changes or run `yarn test -u` to update them.

Test Suites: 2 failed, 11 passed, 13 total
Tests:       2 failed, 101 passed, 103 total
Snapshots:   1 failed, 45 passed, 46 total
Time:        7.268s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[~/size-limit]$
```

after:
```
[~/size-limit]$ yarn test                                                                                                                                           *[pp-macos-specs][ruby-2.6.1]
yarn run v1.22.4
$ jest-ci --coverage --forceExit && eslint-ci . && yarn spell
 PASS  packages/size-limit/test/bin.test.js
 PASS  packages/time/test/index.test.js
 PASS  packages/file/test/index.test.js
 PASS  packages/time/test/ci.test.js
 PASS  packages/size-limit/test/size-limit-error.test.js
 PASS  packages/time/test/cache.test.js
 PASS  packages/size-limit/test/create-reporter.test.js
 PASS  packages/dual-publish/test/index.test.js
 PASS  packages/size-limit/test/get-config.test.js
 PASS  packages/size-limit/test/index.test.js
 PASS  packages/webpack/test/index.test.js
 PASS  packages/size-limit/test/run.test.js
 PASS  packages/time/test/get-running-time.test.js (5.905s)

Test Suites: 13 passed, 13 total
Tests:       103 passed, 103 total
Snapshots:   46 passed, 46 total
Time:        7.04s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
No errors.
Checking finished: 1.177 sec.
✨  Done in 13.05s.
[~/size-limit]$
```