### PR TITLE
Improvement for setMaxListeners

### DIFF
--- a/packages/size-limit/calc.js
+++ b/packages/size-limit/calc.js
@@ -1,5 +1,5 @@
 module.exports = async function calc (plugins, config, createSpinner) {
-  process.setMaxListeners(config.checks.reduce((a, i) => a + i.path.length, 0))
+  process.setMaxListeners(config.checks.reduce((a, i) => a + i.path.length, 1))
 
   async function step (number) {
     for (let plugin of plugins.list) {


### PR DESCRIPTION
related to this issue: https://github.com/ai/size-limit/issues/184

these fixes:
#150
#149

stopped working in version 4.2 (https://github.com/ai/size-limit/commit/f3f44dc94270d4daf54493fbb0662791ffda1279#diff-a1a166c1c48dcde0ef1338a880cb707aR2)

Currently always exists +1 listener

[4.5.2](https://github.com/pustovalov/size-limit-test/tree/4.5.2)
```
[~/dev/oss/size-limit-test]$ yarn size                                                                                                                                        *[4.5.2]
yarn run v1.22.4
$ yarn size-limit
$ /Users/pavel/dev/oss/size-limit-test/node_modules/.bin/size-limit
Count of files: 16
⠋ Running JS in headless Chrome(node:88579) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 17 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
(node:88579) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 17 SIGTERM listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(node:88579) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 17 SIGHUP listeners added to [process]. Use emitter.setMaxListeners() to increase limit
✔ Running JS in headless Chrome
```


[4.1.0](https://github.com/pustovalov/size-limit-test/tree/4.1.0)
```
[~/dev/oss/size-limit-test]$ yarn size                                                                                                                                        *[4.1.0]
yarn run v1.22.4
$ yarn size-limit
$ /Users/pavel/dev/oss/size-limit-test/node_modules/.bin/size-limit

  public/packs-test/vendors-78d576f383843f159a2d.js
```

with changes from PR:
```
[~/dev/oss/size-limit-test]$ yarn size                                                                                                                                          [4.5.2]
yarn run v1.22.4
$ yarn size-limit
$ /Users/pavel/dev/oss/size-limit-test/node_modules/.bin/size-limit
✔ Running JS in headless Chrome

  public/packs-test/vendors-78d576f383843f159a2d.js
```