### PR TITLE
add check for missing DIR parameter of save-bundle argument

### DIFF
--- a/packages/size-limit/parse-args.js
+++ b/packages/size-limit/parse-args.js
@@ -12,7 +12,11 @@ module.exports = function parseArgs (plugins, argv) {
       if (!plugins.has('webpack')) {
         throw new SizeLimitError('argWithoutWebpack', 'save-bundle')
       }
-      args.saveBundle = argv[++i]
+      let nextArg = argv[++i]
+      if (!nextArg || nextArg.startsWith('--')) {
+        throw new SizeLimitError('argWithoutParameter', 'save-bundle', 'DIR')
+      }
+      args.saveBundle = nextArg
     } else if (arg === '--clean-dir') {
       if (!argv.includes('--save-bundle')) {
         throw new SizeLimitError(

--- a/packages/size-limit/size-limit-error.js
+++ b/packages/size-limit/size-limit-error.js
@@ -9,6 +9,8 @@ const MESSAGES = {
     (arg === 'why' ? '. You can add Bundle Analyzer to you own bundler.' : ''),
   argWithoutAnotherArg: (arg, anotherArg) =>
     `Argument *--${arg}* works only with *--${anotherArg}* argument`,
+  argWithoutParameter: (arg, parameter) =>
+    `Missing parameter *${parameter}* for *--${arg}* argument`,
   noConfig: () => 'Create Size Limit config in *package.json*',
   noArrayConfig: () => 'Size Limit config must contain *an array*',
   emptyConfig: () => 'Size Limit config must *not be empty*',

--- a/packages/size-limit/test/__snapshots__/run.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/run.test.js.snap
@@ -305,6 +305,16 @@ exports[`throws on --clean-dir argument without --save-bundle 1`] = `
 "
 `;
 
+exports[`throws on --save-bundle argument without DIR parameter 1`] = `
+"[41m[30m ERROR [39m[49m [31mMissing parameter [33mDIR[31m for [33m--save-bundle[31m argument[39m
+"
+`;
+
+exports[`throws on --save-bundle argument without DIR parameter 2`] = `
+"[41m[30m ERROR [39m[49m [31mMissing parameter [33mDIR[31m for [33m--save-bundle[31m argument[39m
+"
+`;
+
 exports[`throws on --save-bundle argument without webpack 1`] = `
 "[41m[30m ERROR [39m[49m [31mArgument [33m--save-bundle[31m works only with [33m@size-limit/webpack[31m plugin[39m
 "

--- a/packages/size-limit/test/run.test.js
+++ b/packages/size-limit/test/run.test.js
@@ -156,6 +156,13 @@ it('throws on --save-bundle argument without webpack', async () => {
   expect(await error('file', ['--save-bundle'])).toMatchSnapshot()
 })
 
+it('throws on --save-bundle argument without DIR parameter', async () => {
+  expect(await error('webpack', ['--save-bundle'])).toMatchSnapshot()
+  expect(
+    await error('webpack', ['--save-bundle', '--clean-dir'])
+  ).toMatchSnapshot()
+})
+
 it('throws on --clean-dir argument without --save-bundle', async () => {
   expect(await error('file', ['--clean-dir'])).toMatchSnapshot()
 })


### PR DESCRIPTION
I made this PR, because of two reasons. The first one is the command

```
size-limit --save-bundle
```

does't save bundle and trigger any errors. And the second one is

```
size-limit --save-bundle --clean-dir
```

saves bundle to `--clean-dir` folder.