### PR TITLE
Add `--hide-passed` flag to only output failed checks

### DIFF
--- a/packages/size-limit/create-reporter.js
+++ b/packages/size-limit/create-reporter.js
@@ -67,6 +67,8 @@ function createHumanReporter (process) {
     results (plugins, config) {
       print('')
       for (let check of config.checks) {
+        if (check.passed && config.quiet) continue
+
         let unlimited = typeof check.passed === 'undefined'
         let rows = []
 

--- a/packages/size-limit/create-reporter.js
+++ b/packages/size-limit/create-reporter.js
@@ -67,7 +67,7 @@ function createHumanReporter (process) {
     results (plugins, config) {
       print('')
       for (let check of config.checks) {
-        if (check.passed && config.quiet) continue
+        if (check.passed && config.hidePassed) continue
 
         let unlimited = typeof check.passed === 'undefined'
         let rows = []

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -19,7 +19,7 @@ let OPTIONS = {
   running: 'time',
   disableModuleConcatenation: 'webpack',
   brotli: 'webpack',
-  quiet: false
+  hidePassed: false
 }
 
 function isStrings (value) {
@@ -88,8 +88,8 @@ module.exports = async function getConfig (plugins, process, args, pkg) {
   if (args.cleanDir) {
     config.cleanDir = args.cleanDir
   }
-  if (args.quiet) {
-    config.quiet = args.quiet
+  if (args.hidePassed) {
+    config.hidePassed = args.hidePassed
   }
 
   if (args.files.length > 0) {

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -18,7 +18,8 @@ let OPTIONS = {
   gzip: ['webpack', 'file'],
   running: 'time',
   disableModuleConcatenation: 'webpack',
-  brotli: 'webpack'
+  brotli: 'webpack',
+  quiet: false
 }
 
 function isStrings (value) {
@@ -86,6 +87,9 @@ module.exports = async function getConfig (plugins, process, args, pkg) {
   }
   if (args.cleanDir) {
     config.cleanDir = args.cleanDir
+  }
+  if (args.quiet) {
+    config.quiet = args.quiet
   }
 
   if (args.files.length > 0) {

--- a/packages/size-limit/parse-args.js
+++ b/packages/size-limit/parse-args.js
@@ -26,8 +26,8 @@ module.exports = function parseArgs (plugins, argv) {
         )
       }
       args.cleanDir = true
-    } else if (arg === '--quiet') {
-      args.quiet = true
+    } else if (arg === '--hide-passed') {
+      args.hidePassed = true
     } else if (arg === '--why') {
       if (!plugins.has('webpack')) {
         throw new SizeLimitError('argWithoutWebpack', 'why')

--- a/packages/size-limit/parse-args.js
+++ b/packages/size-limit/parse-args.js
@@ -26,6 +26,8 @@ module.exports = function parseArgs (plugins, argv) {
         )
       }
       args.cleanDir = true
+    } else if (arg === '--quiet') {
+      args.quiet = true
     } else if (arg === '--why') {
       if (!plugins.has('webpack')) {
         throw new SizeLimitError('argWithoutWebpack', 'why')

--- a/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`only renders failed results with --quiet flag 1`] = `
+exports[`only renders failed results with --hide-passed flag 1`] = `
 "  
   [1msmall fail[22m
   [31mPackage size limit has exceeded by 1 B[39m

--- a/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`only renders failed results with --quiet flag 1`] = `
+"  
+  [1msmall fail[22m
+  [31mPackage size limit has exceeded by 1 B[39m
+  Size limit: [31m[1m102400 B[22m[39m
+  Size:       [31m[1m102401 B[22m[39m [90mgzipped[39m
+  
+  [1mbig fail[22m
+  [31mPackage size limit has exceeded by 100 B[39m
+  Size limit: [31m[1m100 KB[22m[39m
+  Size:       [31m[1m100.1 KB[22m[39m [90mgzipped[39m
+  
+  [33mTry to reduce size or increase limit in [1m\\"size-limit\\"[22m section of [1mpackage.json[22m[39m
+"
+`;
+
 exports[`renders JSON results 1`] = `
 "[
   {

--- a/packages/size-limit/test/create-reporter.test.js
+++ b/packages/size-limit/test/create-reporter.test.js
@@ -84,7 +84,7 @@ it('renders failed results', () => {
   ).toMatchSnapshot()
 })
 
-it('only renders failed results with --quiet flag', () => {
+it('only renders failed results with --hide-passed flag', () => {
   expect(
     results(['file'], {
       checks: [
@@ -107,7 +107,7 @@ it('only renders failed results with --quiet flag', () => {
           passed: false
         }
       ],
-      quiet: true,
+      hidePassed: true,
       failed: true,
       configPath: 'package.json'
     })

--- a/packages/size-limit/test/create-reporter.test.js
+++ b/packages/size-limit/test/create-reporter.test.js
@@ -84,6 +84,36 @@ it('renders failed results', () => {
   ).toMatchSnapshot()
 })
 
+it('only renders failed results with --quiet flag', () => {
+  expect(
+    results(['file'], {
+      checks: [
+        {
+          name: 'ok',
+          size: 102400,
+          sizeLimit: 102400,
+          passed: true
+        },
+        {
+          name: 'small fail',
+          size: 102401,
+          sizeLimit: 102400,
+          passed: false
+        },
+        {
+          name: 'big fail',
+          size: 102500,
+          sizeLimit: 102400,
+          passed: false
+        }
+      ],
+      quiet: true,
+      failed: true,
+      configPath: 'package.json'
+    })
+  ).toMatchSnapshot()
+})
+
 it('renders single result', () => {
   expect(
     results(['file'], {

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -100,12 +100,13 @@ it('overrides limit by CLI arg', async () => {
 })
 
 it('normalizes bundle and webpack arguments', async () => {
-  let args = ['--why', '--save-bundle', 'out', '--clean-dir']
+  let args = ['--why', '--save-bundle', 'out', '--clean-dir', '--quiet']
   expect(await check('webpack', args)).toEqual({
     configPath: 'package.json',
     cwd: fixture('webpack'),
     why: true,
     project: 'webpack',
+    quiet: true,
     saveBundle: fixture('webpack', 'out'),
     cleanDir: true,
     checks: [

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -100,13 +100,13 @@ it('overrides limit by CLI arg', async () => {
 })
 
 it('normalizes bundle and webpack arguments', async () => {
-  let args = ['--why', '--save-bundle', 'out', '--clean-dir', '--quiet']
+  let args = ['--why', '--save-bundle', 'out', '--clean-dir', '--hide-passed']
   expect(await check('webpack', args)).toEqual({
     configPath: 'package.json',
     cwd: fixture('webpack'),
     why: true,
     project: 'webpack',
-    quiet: true,
+    hidePassed: true,
     saveBundle: fixture('webpack', 'out'),
     cleanDir: true,
     checks: [


### PR DESCRIPTION
The output can be very long if you have a lot of bundles that you're checking. The `--hide-passed` option will only output check failures.