### PR TITLE
Emit Webpack stats JSON file

### DIFF
--- a/packages/size-limit/create-reporter.js
+++ b/packages/size-limit/create-reporter.js
@@ -8,6 +8,7 @@ let {
   red,
   yellow
 } = require('colorette')
+let { normalize } = require('path')
 let bytes = require('bytes')
 
 function createJsonReporter (process) {
@@ -171,6 +172,12 @@ function createHumanReporter (process) {
           fix += bold(config.configPath)
         }
         print(yellow(fix))
+      }
+
+      if (plugins.has('webpack') && config.saveBundle) {
+        let statsFilepath = normalize(config.saveBundle, 'stats.json')
+        print(`Webpack Stats file was saved to ${statsFilepath}`)
+        print('You can review it using https://webpack.github.io/analyse')
       }
     }
   }

--- a/packages/size-limit/create-reporter.js
+++ b/packages/size-limit/create-reporter.js
@@ -8,7 +8,7 @@ let {
   red,
   yellow
 } = require('colorette')
-let { normalize } = require('path')
+let { join } = require('path')
 let bytes = require('bytes')
 
 function createJsonReporter (process) {
@@ -175,7 +175,7 @@ function createHumanReporter (process) {
       }
 
       if (plugins.has('webpack') && config.saveBundle) {
-        let statsFilepath = normalize(config.saveBundle, 'stats.json')
+        let statsFilepath = join(config.saveBundle, 'stats.json')
         print(`Webpack Stats file was saved to ${statsFilepath}`)
         print('You can review it using https://webpack.github.io/analyse')
       }

--- a/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
@@ -115,7 +115,7 @@ exports[`renders results 1`] = `
   Running time: [32m[1m2 s   [22m[39m [90mon Snapdragon 410[39m
   Total time:   [32m[1m3 s[22m[39m
   
-  Webpack Stats file was saved to /var/folders/44/r0s26_lj75v0fds12xfnjfb80000gn/T/size-limit-test
+  Webpack Stats file was saved to /var/folders/44/r0s26_lj75v0fds12xfnjfb80000gn/T/size-limit-test/stats.json
   You can review it using https://webpack.github.io/analyse
 "
 `;

--- a/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
@@ -115,6 +115,8 @@ exports[`renders results 1`] = `
   Running time: [32m[1m2 s   [22m[39m [90mon Snapdragon 410[39m
   Total time:   [32m[1m3 s[22m[39m
   
+  Webpack Stats file was saved to /var/folders/44/r0s26_lj75v0fds12xfnjfb80000gn/T/size-limit-test
+  You can review it using https://webpack.github.io/analyse
 "
 `;
 

--- a/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
@@ -52,6 +52,13 @@ exports[`renders JSON results 1`] = `
 "
 `;
 
+exports[`renders Webpack stats help message 1`] = `
+"  
+  Webpack Stats file was saved to test/stats.json
+  You can review it using https://webpack.github.io/analyse
+"
+`;
+
 exports[`renders config-less result 1`] = `
 "  
   [31mTotal time limit has exceeded[39m
@@ -115,8 +122,6 @@ exports[`renders results 1`] = `
   Running time: [32m[1m2 s   [22m[39m [90mon Snapdragon 410[39m
   Total time:   [32m[1m3 s[22m[39m
   
-  Webpack Stats file was saved to /var/folders/44/r0s26_lj75v0fds12xfnjfb80000gn/T/size-limit-test/stats.json
-  You can review it using https://webpack.github.io/analyse
 "
 `;
 

--- a/packages/size-limit/test/create-reporter.test.js
+++ b/packages/size-limit/test/create-reporter.test.js
@@ -1,6 +1,3 @@
-let { join } = require('path')
-let { tmpdir } = require('os')
-
 let createReporter = require('../create-reporter')
 
 function results (types, config, isJSON = false) {
@@ -53,9 +50,7 @@ it('renders results', () => {
           time: 3,
           passed: true
         }
-      ],
-      cleanDir: true,
-      saveBundle: join(tmpdir(), `size-limit-test`)
+      ]
     })
   ).toMatchSnapshot()
 })
@@ -227,6 +222,15 @@ it('renders result for file without gzip', () => {
       ],
       failed: false,
       configPath: '.size-limit.json'
+    })
+  ).toMatchSnapshot()
+})
+
+it('renders Webpack stats help message', () => {
+  expect(
+    results(['webpack'], {
+      checks: [],
+      saveBundle: 'test'
     })
   ).toMatchSnapshot()
 })

--- a/packages/size-limit/test/create-reporter.test.js
+++ b/packages/size-limit/test/create-reporter.test.js
@@ -1,3 +1,6 @@
+let { join } = require('path')
+let { tmpdir } = require('os')
+
 let createReporter = require('../create-reporter')
 
 function results (types, config, isJSON = false) {
@@ -50,7 +53,9 @@ it('renders results', () => {
           time: 3,
           passed: true
         }
-      ]
+      ],
+      cleanDir: true,
+      saveBundle: join(tmpdir(), `size-limit-test`)
     })
   ).toMatchSnapshot()
 })

--- a/packages/webpack/get-config.js
+++ b/packages/webpack/get-config.js
@@ -92,6 +92,14 @@ module.exports = async function getConfig (limitConfig, check, output) {
         analyzerPort: 8888 + limitConfig.checks.findIndex(i => i === check)
       })
     )
+  } else if (limitConfig.saveBundle) {
+    config.plugins.push(
+      new BundleAnalyzerPlugin({
+        openAnalyzer: false,
+        analyzerMode: 'disabled',
+        generateStatsFile: true
+      })
+    )
   }
 
   return config

--- a/packages/webpack/test/index.test.js
+++ b/packages/webpack/test/index.test.js
@@ -173,6 +173,7 @@ it('supports --save-bundle', async () => {
   }
   await run(config)
   expect(existsSync(join(DIST, 'index.js'))).toBe(true)
+  expect(existsSync(join(DIST, 'stats.json'))).toBe(true)
 })
 
 it('supports --clean-dir', async () => {


### PR DESCRIPTION
This PR utilises `BundleAnalyzerPlugin` to emit Webpack stats file alongside with the bundle when `--save-bundle` is used. It comes handy when one wants to inspect the bundle as [Webpack’s analyser](http://webpack.github.io/analyse) could be used to find out more about reasons why some dependency was included.