### PR TITLE
Look up for plugins in parent package.json

### DIFF
--- a/packages/size-limit/load-plugins.js
+++ b/packages/size-limit/load-plugins.js
@@ -14,7 +14,7 @@ class Plugins {
 }
 
 module.exports = function loadPlugins (pkg) {
-  if (!pkg || !pkg.packageJson) return []
+  if (!pkg || !pkg.packageJson) return new Plugins([])
 
   let list = toArray(pkg.packageJson.dependencies)
     .concat(toArray(pkg.packageJson.devDependencies))

--- a/packages/size-limit/test/__snapshots__/run.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/run.test.js.snap
@@ -7,6 +7,14 @@ exports[`run allows to use peer dependencies in import 1`] = `
 "
 `;
 
+exports[`run find plugins in parent package.json 1`] = `
+"  
+  Size limit: [32m[1m1 KB[22m[39m
+  Size:       [32m[1m20 B[22m[39m [90mgzipped[39m
+  
+"
+`;
+
 exports[`run returns zero bytes for empty file 1`] = `
 "  
   Size limit: [32m[1m0 B[22m[39m

--- a/packages/size-limit/test/fixtures/nested/package.json
+++ b/packages/size-limit/test/fixtures/nested/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "file",
+  "private": true,
+  "devDependencies": {
+    "@size-limit/file": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/packages/size-limit/test/fixtures/nested/package/package.json
+++ b/packages/size-limit/test/fixtures/nested/package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package",
+  "private": true,
+  "size-limit": [
+    {
+      "name": "index",
+      "limit": "1 KB"
+    }
+  ]
+}

--- a/packages/size-limit/test/run.test.js
+++ b/packages/size-limit/test/run.test.js
@@ -42,7 +42,7 @@ function createProcess (cwd, args = []) {
       if (cwd.includes('/')) {
         return cwd
       } else {
-        return fixture(cwd)
+        return fixture(...(Array.isArray(cwd) ? cwd : [cwd]))
       }
     },
     exit (code) {
@@ -290,5 +290,9 @@ describe(`run`, () => {
 
   it('shows debug on error', async () => {
     expect(clean(await error('internal-error', ['--debug']))).toMatchSnapshot()
+  })
+
+  it('find plugins in parent package.json', async () => {
+    expect(clean(await check(['nested', 'package']))).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Fixes #153 

I do not use `require.resolve`, cause too much logic inside relied on `process.cwd`, instead I decided to find plugins in parent `package.json` dependencies.