### PR TITLE
Add statoscope plugin

### DIFF
--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -83,6 +83,10 @@ module.exports = async function getConfig(plugins, process, args, pkg) {
     config.project = pkg.packageJson.name
     config.why = args.why
   }
+  if (args.whyStatoscope) {
+    config.project = pkg.packageJson.name
+    config.whyStatoscope = args.whyStatoscope
+  }
   if (args.saveBundle) {
     config.saveBundle = toAbsolute(args.saveBundle, process.cwd())
   }

--- a/packages/size-limit/parse-args.js
+++ b/packages/size-limit/parse-args.js
@@ -33,7 +33,34 @@ module.exports = function parseArgs(plugins, argv) {
       if (!plugins.has('webpack')) {
         throw new SizeLimitError('argWithoutWebpack', 'why')
       }
+      if (argv.includes('--why-statoscope')) {
+        throw new SizeLimitError('conflictingArgs', 'why', 'why-statoscope')
+      }
       args.why = true
+    } else if (arg === '--why-statoscope') {
+      if (!plugins.has('webpack')) {
+        throw new SizeLimitError('argWithoutWebpack', 'why-statoscope')
+      }
+      if (argv.includes('--why')) {
+        throw new SizeLimitError('conflictingArgs', 'why-statoscope', 'why')
+      }
+      args.whyStatoscope = true
+    } else if (arg === '--compare-with') {
+      if (!plugins.has('webpack')) {
+        throw new SizeLimitError('argWithoutWebpack', '--compare-with')
+      }
+      if (!argv.includes('--why-statoscope')) {
+        throw new SizeLimitError(
+          'argWithoutAnotherArg',
+          'compare-with',
+          'why-statoscope'
+        )
+      }
+      let nextArg = argv[++i]
+      if (!nextArg || nextArg.startsWith('--')) {
+        throw new SizeLimitError('argWithoutParameter', 'compare-with', 'FILE')
+      }
+      args.compareWith = nextArg
     } else if (arg === '--watch') {
       args.watch = true
     } else if (arg === '--highlight-less') {

--- a/packages/size-limit/size-limit-error.js
+++ b/packages/size-limit/size-limit-error.js
@@ -11,6 +11,8 @@ const MESSAGES = {
     `Argument *--${arg}* works only with *--${anotherArg}* argument`,
   argWithoutParameter: (arg, parameter) =>
     `Missing parameter *${parameter}* for *--${arg}* argument`,
+  conflictingArgs: (arg, anotherArg) =>
+    `Argument *--${arg}* conficts with *--${anotherArg}*. You should use either *--${arg}* or *--${anotherArg}*`,
   noConfig: () => 'Create Size Limit config in *package.json*',
   noArrayConfig: () => 'Size Limit config must contain *an array*',
   emptyConfig: () => 'Size Limit config must *not be empty*',

--- a/packages/size-limit/test/__snapshots__/run.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/run.test.js.snap
@@ -361,6 +361,21 @@ exports[`run throws on --clean-dir argument without --save-bundle 1`] = `
 "
 `;
 
+exports[`run throws on --compare-with argument without --why-statoscope 1`] = `
+"[41m[30m ERROR [39m[49m [31mArgument [33m--compare-with[31m works only with [33m--why-statoscope[31m argument[39m
+"
+`;
+
+exports[`run throws on --compare-with argument without value 1`] = `
+"[41m[30m ERROR [39m[49m [31mMissing parameter [33mFILE[31m for [33m--compare-with[31m argument[39m
+"
+`;
+
+exports[`run throws on --compare-with argument without webpack 1`] = `
+"[41m[30m ERROR [39m[49m [31mArgument [33m----compare-with[31m works only with [33m@size-limit/webpack[31m plugin[39m
+"
+`;
+
 exports[`run throws on --save-bundle argument without DIR parameter 1`] = `
 "[41m[30m ERROR [39m[49m [31mMissing parameter [33mDIR[31m for [33m--save-bundle[31m argument[39m
 "
@@ -376,9 +391,26 @@ exports[`run throws on --save-bundle argument without webpack 1`] = `
 "
 `;
 
+exports[`run throws on --why argument with --why-statoscope 1`] = `
+"[41m[30m ERROR [39m[49m [31mArgument [33m--why[31m conficts with [33m--why-statoscope[31m.
+        You should use either [33m--why[31m or [33m--why-statoscope[31m[39m
+"
+`;
+
 exports[`run throws on --why argument without webpack 1`] = `
 "[41m[30m ERROR [39m[49m [31mArgument [33m--why[31m works only with [33m@size-limit/webpack[31m plugin.
         You can add Bundle Analyzer to you own bundler.[39m
+"
+`;
+
+exports[`run throws on --why-statoscope argument with --why 1`] = `
+"[41m[30m ERROR [39m[49m [31mArgument [33m--why-statoscope[31m conficts with [33m--why[31m.
+        You should use either [33m--why-statoscope[31m or [33m--why[31m[39m
+"
+`;
+
+exports[`run throws on --why-statoscope argument without webpack 1`] = `
+"[41m[30m ERROR [39m[49m [31mArgument [33m--why-statoscope[31m works only with [33m@size-limit/webpack[31m plugin[39m
 "
 `;
 

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -128,6 +128,37 @@ it('normalizes bundle and webpack arguments', async () => {
   })
 })
 
+it('normalizes bundle and webpack arguments with --why-statoscope', async () => {
+  let args = [
+    '--why-statoscope',
+    '--save-bundle',
+    'out',
+    '--compare-with',
+    'before.json',
+    '--clean-dir',
+    '--hide-passed',
+    '--highlight-less'
+  ]
+  expect(await check('webpack', args)).toEqual({
+    configPath: 'package.json',
+    cwd: fixture('webpack'),
+    whyStatoscope: true,
+    project: 'webpack',
+    hidePassed: true,
+    highlightLess: true,
+    saveBundle: fixture('webpack', 'out'),
+    cleanDir: true,
+    checks: [
+      {
+        name: 'a',
+        highlightLess: true,
+        config: fixture('webpack', 'webpack.config.js'),
+        entry: ['a']
+      }
+    ]
+  })
+})
+
 it('uses peerDependencies as ignore option', async () => {
   expect(await check('peer')).toEqual({
     configPath: '.size-limit.json',

--- a/packages/size-limit/test/run.test.js
+++ b/packages/size-limit/test/run.test.js
@@ -172,6 +172,36 @@ describe(`run`, () => {
     expect(await error('file', ['--why'])).toMatchSnapshot()
   })
 
+  it('throws on --why argument with --why-statoscope', async () => {
+    expect(
+      await error('webpack', ['--why', '--why-statoscope'])
+    ).toMatchSnapshot()
+  })
+
+  it('throws on --why-statoscope argument without webpack', async () => {
+    expect(await error('file', ['--why-statoscope'])).toMatchSnapshot()
+  })
+
+  it('throws on --why-statoscope argument with --why', async () => {
+    expect(
+      await error('webpack', ['--why-statoscope', '--why'])
+    ).toMatchSnapshot()
+  })
+
+  it('throws on --compare-with argument without webpack', async () => {
+    expect(await error('file', ['--compare-with'])).toMatchSnapshot()
+  })
+
+  it('throws on --compare-with argument without --why-statoscope', async () => {
+    expect(await error('webpack', ['--compare-with'])).toMatchSnapshot()
+  })
+
+  it('throws on --compare-with argument without value', async () => {
+    expect(
+      await error('webpack', ['--why-statoscope', '--compare-with'])
+    ).toMatchSnapshot()
+  })
+
   it('throws on no config', async () => {
     expect(await error('file')).toMatchSnapshot()
   })

--- a/packages/time/test/get-running-time.test.js
+++ b/packages/time/test/get-running-time.test.js
@@ -7,7 +7,7 @@ let { saveCache, getCache } = require('../cache')
 
 const EXAMPLE = require.resolve('nanoid/index.browser.js')
 
-jest.setTimeout(10000)
+jest.setTimeout(15000)
 
 afterEach(async () => {
   delete process.env.SIZE_LIMIT_FAKE_TIME

--- a/packages/webpack/get-config.js
+++ b/packages/webpack/get-config.js
@@ -1,4 +1,5 @@
 let { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+let StatoscopeWebpackPlugin = require('@statoscope/ui-webpack')
 let PnpWebpackPlugin = require('pnp-webpack-plugin')
 let { promisify } = require('util')
 let escapeRegexp = require('escape-string-regexp')
@@ -83,7 +84,23 @@ module.exports = async function getConfig(limitConfig, check, output) {
     }
   }
 
-  if (limitConfig.why) {
+  if (limitConfig.whyStatoscope) {
+    let shouldOpen = process.env.NODE_ENV !== 'test' && !limitConfig.saveBundle
+    config.plugins.push(
+      new StatoscopeWebpackPlugin({
+        saveTo: join(output, 'statoscope.html'),
+        saveStatsTo: limitConfig.saveBundle
+          ? join(output, 'statoscope.json')
+          : undefined,
+        additionalStats: limitConfig.compareWith
+          ? limitConfig.compareWith
+          : undefined,
+        open: shouldOpen ? 'file' : false,
+        name: limitConfig.project,
+        watchMode: limitConfig.watch
+      })
+    )
+  } else if (limitConfig.why) {
     config.plugins.push(
       new BundleAnalyzerPlugin({
         openAnalyzer: process.env.NODE_ENV !== 'test',

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -30,7 +30,8 @@
     "rimraf": "^3.0.2",
     "style-loader": "^2.0.0",
     "webpack": "^4.44.1",
-    "webpack-bundle-analyzer": "^4.4.0"
+    "webpack-bundle-analyzer": "^4.4.0",
+    "@statoscope/ui-webpack": "^3.5.0"
   },
   "devDependencies": {
     "redux": "^4.0.5"

--- a/packages/webpack/test/index.test.js
+++ b/packages/webpack/test/index.test.js
@@ -166,6 +166,24 @@ it('supports --why', async () => {
   }
 })
 
+it('supports --why-statoscope', async () => {
+  jest.spyOn(console, 'log').mockImplementation(() => true)
+  let config = {
+    project: 'superProject',
+    whyStatoscope: true,
+    checks: [{ files: [fixture('big.js')] }]
+  }
+  try {
+    await webpack.step20(config, config.checks[0])
+    await webpack.step40(config, config.checks[0])
+    let reportFile = join(config.checks[0].webpackOutput, 'statoscope.html')
+    let reportHTML = (await readFile(reportFile)).toString()
+    expect(reportHTML).toContain('superProject')
+  } finally {
+    await webpack.finally(config, config.checks[0])
+  }
+})
+
 it('supports --save-bundle', async () => {
   let config = {
     saveBundle: DIST,

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,6 +315,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@discoveryjs/json-ext@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz#8f03a22a04de437254e8ce8cc84ba39689288752"
+  integrity sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -570,6 +575,14 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@statoscope/ui-webpack@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@statoscope/ui-webpack/-/ui-webpack-3.5.0.tgz#093855f03f681b25764a2689ff4a178b0cbf978e"
+  integrity sha512-mNVAIa64zdLu0JrNFkOVAHJlxnvrMCZg7RDkNzJw2TixxPOY6KQ2yBCSBnIUlA1uF7zHoG9ZCFz7CDJVZzaCkw==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.2"
+    open "^7.4.2"
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
@@ -3894,7 +3907,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -5213,6 +5226,14 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
 
 opener@^1.5.2:
   version "1.5.2"


### PR DESCRIPTION
Hello 👋

This PR adds support of new statoscope plugin: https://github.com/smelukov/statoscope

Why: BundleAnalyzer is extremely popular and powerful tool for keeping our bundle in fit, but it doesn't have some useful features:
1) He can't tell me why some dep is added
2) He can't compare builds between each other (I'd like to compare feature branch with actual main)
3) He doesn't show me deoptimizations and why are they happened.

Statoscope covers all these cases and shows chunks map (like the BundleAnalyser does)