### PR TITLE
add `modifyWebpackConfig` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Each section in the config can have these options:
 * **config**: a path to a custom webpack config.
 * **ignore**: an array of files and dependencies to exclude from
   the project size calculation.
+* **modifyWebpackConfig**: (.size-limit.js only) function that can be used to do last-minute changes to the webpack config, like adding a plugin
 
 If you use Size Limit to track the size of CSS files, make sure to set
 `webpack: false`. Otherwise, you will get wrong numbers, because webpack

--- a/README.md
+++ b/README.md
@@ -505,7 +505,8 @@ Each section in the config can have these options:
 * **config**: a path to a custom webpack config.
 * **ignore**: an array of files and dependencies to exclude from
   the project size calculation.
-* **modifyWebpackConfig**: (.size-limit.js only) function that can be used to do last-minute changes to the webpack config, like adding a plugin
+* **modifyWebpackConfig**: (.size-limit.js only) function that can be used to 
+  do last-minute changes to the webpack config, like adding a plugin.
 
 If you use Size Limit to track the size of CSS files, make sure to set
 `webpack: false`. Otherwise, you will get wrong numbers, because webpack

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
       "brotli",
       "PnP",
       "ES",
-      "GitHub"
+      "GitHub",
+      "modifyWebpackConfig"
     ]
   },
   "sharec": {

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -12,6 +12,7 @@ let OPTIONS = {
   module: true,
   entry: 'webpack',
   config: 'webpack',
+  modifyWebpackConfig: 'webpack',
   webpack: 'webpack',
   ignore: 'webpack',
   import: 'webpack',

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -77,6 +77,9 @@ let self = {
       convertConfig(check.webpackConfig, config.configPath)
     } else {
       check.webpackConfig = await getConfig(config, check, check.webpackOutput)
+      if (check.modifyWebpackConfig) {
+        check.webpackConfig = check.modifyWebpackConfig(check.webpackConfig)
+      }
     }
   },
 

--- a/packages/webpack/test/fixtures/referencingAlias.js
+++ b/packages/webpack/test/fixtures/referencingAlias.js
@@ -1,0 +1,1 @@
+export { methodA } from '@fixtures/module'

--- a/packages/webpack/test/index.test.js
+++ b/packages/webpack/test/index.test.js
@@ -279,3 +279,23 @@ it('supports import with multiple files', async () => {
     })
   ).toEqual(5)
 })
+
+it('can use `modifyWebpackConfig` for resolution of aliases', async () => {
+  let { NormalModuleReplacementPlugin } = require('webpack')
+  expect(
+    await getSize({
+      import: {
+        [fixture('referencingAlias.js')]: '{ methodA }'
+      },
+      modifyWebpackConfig(config) {
+        config.plugins.push(
+          new NormalModuleReplacementPlugin(
+            /@fixtures\/module/,
+            fixture('module.js')
+          )
+        )
+        return config
+      }
+    })
+  ).toEqual(79)
+})


### PR DESCRIPTION
So, we want to use this for `@reduxjs/toolkit` which will have multiple entry points from the next version that reference each other, so we need to add the `NormalModuleReplacementPlugin`.

Rather than creating a bunch of fixed webpack configs that don't work with `--why`, this allows to just do some last-minute changes to the webpack config.

Hope you'll accept this - it would be a great help for us :slightly_smiling_face: 

### Example usage:

Usage in our case looks like this:
```js
function withRtkPath(path) {
  return (config) => {
    const rtkPath = path.replace(
      /(query\/rtk-query|query\/react\/rtk-query-react)/,
      'redux-toolkit'
    )
    config.plugins.push(
      new webpack.NormalModuleReplacementPlugin(
        /@reduxjs\/toolkit/,
        join(__dirname, rtkPath)
      )
    )
    return config
  }
}
// ...
    {
      name: `createApi (${path})`,
      path,
      import: '{ createApi }',
      modifyWebpackConfig: withRtkPath(path),
      ignore: ['react'],
    },
```
with `path` being from the array
```js
const queryEntryPoints = [
  'dist/query/rtk-query.cjs.production.min.js',
  'dist/query/rtk-query.esm.js',
  'dist/query/rtk-query.modern.production.min.js',
]
```