### PR TITLE
Add support for .size-limit.cjs config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Size Limits supports three ways to define config.
    ]
    ```
 
-3. or a more flexible `.size-limit.js` config file:
+3. or a more flexible `.size-limit.js` or `.size-limit.cjs` config file:
 
    ```js
    module.exports = [

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -105,7 +105,8 @@ module.exports = async function getConfig(plugins, process, args, pkg) {
         'package.json',
         '.size-limit.json',
         '.size-limit',
-        '.size-limit.js'
+        '.size-limit.js',
+        '.size-limit.cjs'
       ]
     })
     let result = await explorer.search(process.cwd())


### PR DESCRIPTION
ES Modules cannot be required. This prevents ES Module projects with `"type": "module"` in their package.json from using a .size-limit.js file for config, which restricts the use of the modifyWebpackConfig option introduced in #226. Allowing for a .cjs extension for the config file solves this.

Below is the error message shown after running `size-limit` with a `.size-limit.js` config file in a repo with `"type": "module"`

```js
// .size-limit.js
module.exports = [
  {
    path: 'index.js'
  }
];
```

```bash
$ npx size-limit
 ERROR  Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /path/to/lib/.size-limit.js
require() of ES modules is not supported.
require() of /path/to/lib/.size-limit.js from /path/to/lib/node_modules/lilconfig/dist/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename .size-limit.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /path/to/lib/package.json.
```

I have validated this functions as expected locally, but did not see a place in the test code where specific config file declarations were validated.