### PR TITLE
Add optional dependencies support

### DIFF
--- a/packages/size-limit/load-plugins.js
+++ b/packages/size-limit/load-plugins.js
@@ -18,6 +18,7 @@ module.exports = function loadPlugins(pkg) {
 
   let list = toArray(pkg.packageJson.dependencies)
     .concat(toArray(pkg.packageJson.devDependencies))
+    .concat(toArray(pkg.packageJson.optionalDependencies))
     .filter(i => i.startsWith('@size-limit/'))
     .reduce(
       (all, i) =>


### PR DESCRIPTION
Currently if you install size-limit presets in your as optional dependency (mainly useful not to download chromium if you don't need to in your CI using `--no-optional`) then size-limit will not find plugins.
This PR adds this feature.