### PR TITLE
Save report into tmp dir by default

### DIFF
--- a/packages/webpack/get-config.js
+++ b/packages/webpack/get-config.js
@@ -84,7 +84,9 @@ module.exports = async function getConfig(limitConfig, check, output) {
     let shouldOpen = process.env.NODE_ENV !== 'test' && !limitConfig.saveBundle
     config.plugins.push(
       new StatoscopeWebpackPlugin({
-        saveReportTo: join(output, 'report.html'),
+        saveReportTo: limitConfig.saveBundle
+          ? join(limitConfig.saveBundle, 'report.html')
+          : undefined,
         saveStatsTo: limitConfig.saveBundle
           ? join(limitConfig.saveBundle, 'stats.json')
           : undefined,
@@ -100,8 +102,8 @@ module.exports = async function getConfig(limitConfig, check, output) {
   } else if (limitConfig.saveBundle) {
     config.plugins.push(
       new StatoscopeWebpackPlugin({
+        saveReportTo: join(limitConfig.saveBundle, 'report.html'),
         saveStatsTo: join(limitConfig.saveBundle, 'stats.json'),
-        saveOnlyStats: true,
         open: false,
         watchMode: limitConfig.watch
       })

--- a/packages/webpack/test/index.test.js
+++ b/packages/webpack/test/index.test.js
@@ -150,6 +150,7 @@ it('supports --why', async () => {
   let config = {
     project: 'superProject',
     why: true,
+    saveBundle: DIST,
     checks: [{ files: [fixture('big.js')] }]
   }
   try {


### PR DESCRIPTION
Size-limit clears output directory by default (with statoscope report).
By this PR statoscope will save a report into os temp directory.
Also, we can pass saveBundle directory, and then a report will be saved there