### PR TITLE
docs: fix action version in workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v1
-      - uses: andresz1/size-limit-action@v1.0.0
+      - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
to use latest version, `v1.0.0` is outdated

https://github.com/andresz1/size-limit-action/issues/68#issuecomment-979479985