### PR TITLE
Add support for wildcard importing ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Each section in the config can have these options:
   It could be a path `"index.js"`, a [pattern] `"dist/app-*.js"`
   or an array `["index.js", "dist/app-*.js", "!dist/app-exclude.js"]`.
 * **import**: partial import to test tree-shaking. It could be `"{ lib }"`
-  to test `import { lib } from 'lib'` or `{ "a.js": "{ a }", "b.js": "{ b }" }`
+  to test `import { lib } from 'lib'`, `*` to test `import * as all from 'lib'` or `{ "a.js": "{ a }", "b.js": "{ b }" }`
   to test multiple files.
 * **limit**: size or time limit for files from the `path` option. It should be
   a string with a number and unit, separated by a space.

--- a/packages/esbuild/test/index.test.js
+++ b/packages/esbuild/test/index.test.js
@@ -261,3 +261,13 @@ it('supports import with multiple files', async () => {
     })
   ).toBe(18)
 })
+
+it('supports wildcard imports', async () => {
+  expect(
+    await getSize({
+      import: {
+        [fixture('module.js')]: '*'
+      }
+    })
+  ).toBe(191)
+})

--- a/packages/size-limit/process-import.js
+++ b/packages/size-limit/process-import.js
@@ -9,10 +9,16 @@ module.exports = async function processImport(check, output) {
 
   let loader = ''
   for (let i in check.import) {
+    let imports = `${check.import[i]}`
     let list = check.import[i].replace(/}|{/g, '').trim()
+
+    if (check.import[i] === '*') {
+      imports = `${check.import[i]} as all`
+      list = `all`
+    }
+
     loader +=
-      `import ${check.import[i]} from ${JSON.stringify(i)}\n` +
-      `console.log(${list})\n`
+      `import ${imports} from ${JSON.stringify(i)}\n` + `console.log(${list})\n`
   }
   await mkdirp(output)
   let entry = join(output, 'index.js')


### PR DESCRIPTION
I wanted to allow importing all ESM modules in one by adding support for `import: '*'`