### PR TITLE
chore: update and fix pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,6 @@
     "semi": false,
     "singleQuote": true,
     "trailingComma": "none"
-  }
+  },
+  "packageManager": "pnpm@7.18.0"
 }


### PR DESCRIPTION
The version of pnpm I have on my wsl was old and I notice it generates different lock file.

Updating package.json to indicate this repo is using pnpm and update the version.

If you want to pin it to another version, that works too.