### PR TITLE
fix(README): typos and markdown issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ We are using [Statoscope] for this analysis.
 * [Logux](https://github.com/logux) reduced
   [90% of the size](https://github.com/logux/logux-client/commit/62b258e20e1818b23ae39b9c4cd49e2495781e91).
 
+
 ## How It Works
 
 1. Size Limit contains a CLI tool, 3 plugins (`file`, `webpack`, `time`)
@@ -87,6 +88,7 @@ We are using [Statoscope] for this analysis.
    Note that these measurements depend on available resources and might
    be unstable. [See here](https://github.com/mbalabash/estimo/issues/5)
    for more details.
+
 
 ## Usage
 
@@ -155,6 +157,7 @@ interactive elements, using React/Vue/Svelte lib or vanilla JS.
    to add one — start with [Travis CI].
 
 </details>
+
 
 ### JS Application and Time-based Limit
 
@@ -227,6 +230,7 @@ to track the time a browser takes to compile and execute your JS.
    to add one — start with [Travis CI].
 
 </details>
+
 
 ### Big Libraries
 
@@ -322,6 +326,7 @@ the size in bytes. Libraries like [React] are good examples for this preset.
 
 </details>
 
+
 ### Small Libraries
 
 JS libraries < 10 kB in size.
@@ -408,10 +413,12 @@ for this preset.
 
 </details>
 
+
 [Travis CI]: https://github.com/dwyl/learn-travis
 [Storeon]: https://github.com/ai/storeon/
 [Nano ID]: https://github.com/ai/nanoid/
 [React]: https://github.com/facebook/react/
+
 
 ## Reports
 
@@ -438,6 +445,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
 
 ## Config
 
@@ -472,6 +480,7 @@ Plugin presets:
 
 [`dual-publish`]: https://github.com/ai/dual-publish
 
+
 #### Third-Party Plugins
 
 Third-party plugins and presets named starting with `size-limit-` are also supported.
@@ -482,6 +491,7 @@ For example:
 * [`size-limit-preset-node-lib`](https://github.com/un-ts/size-limit/tree/main/packages/preset-node-lib)
   is like `@size-limit/preset-small-lib` but for Node libraries which contains
   above `node-esbuild` and core `file` plugins.
+
 
 ### Limits Config
 
@@ -559,6 +569,7 @@ inserts `style-loader` runtime (≈2 kB) into the bundle.
 
 [Statoscope docs]: https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin#optionsreports-report
 [pattern]: https://github.com/sindresorhus/globby#globbing-patterns
+
 
 ## JS API
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ We are using [Statoscope] for this analysis.
 * [Logux](https://github.com/logux) reduced
   [90% of the size](https://github.com/logux/logux-client/commit/62b258e20e1818b23ae39b9c4cd49e2495781e91).
 
-
 ## How It Works
 
 1. Size Limit contains a CLI tool, 3 plugins (`file`, `webpack`, `time`)
@@ -89,7 +88,6 @@ We are using [Statoscope] for this analysis.
    be unstable. [See here](https://github.com/mbalabash/estimo/issues/5)
    for more details.
 
-
 ## Usage
 
 ### JS Applications
@@ -104,7 +102,7 @@ interactive elements, using React/Vue/Svelte lib or vanilla JS.
 1. Install the preset:
 
     ```sh
-    $ npm install --save-dev size-limit @size-limit/file
+    npm install --save-dev size-limit @size-limit/file
     ```
 
 2. Add the `size-limit` section and the `size` script to your `package.json`:
@@ -158,7 +156,6 @@ interactive elements, using React/Vue/Svelte lib or vanilla JS.
 
 </details>
 
-
 ### JS Application and Time-based Limit
 
 File size limit (in kB) is not the best way to describe your JS application
@@ -174,7 +171,7 @@ to track the time a browser takes to compile and execute your JS.
 1. Install the preset:
 
     ```sh
-    $ npm install --save-dev size-limit @size-limit/preset-app
+    npm install --save-dev size-limit @size-limit/preset-app
     ```
 
 2. Add the `size-limit` section and the `size` script to your `package.json`:
@@ -231,7 +228,6 @@ to track the time a browser takes to compile and execute your JS.
 
 </details>
 
-
 ### Big Libraries
 
 JS libraries > 10 kB in size.
@@ -246,7 +242,7 @@ the size in bytes. Libraries like [React] are good examples for this preset.
 1. Install preset:
 
     ```sh
-    $ npm install --save-dev size-limit @size-limit/preset-big-lib
+    npm install --save-dev size-limit @size-limit/preset-big-lib
     ```
 
 2. Add the `size-limit` section and the `size` script to your `package.json`:
@@ -326,7 +322,6 @@ the size in bytes. Libraries like [React] are good examples for this preset.
 
 </details>
 
-
 ### Small Libraries
 
 JS libraries < 10 kB in size.
@@ -341,7 +336,7 @@ for this preset.
 1. First, install `size-limit`:
 
     ```sh
-    $ npm install --save-dev size-limit @size-limit/preset-small-lib
+    npm install --save-dev size-limit @size-limit/preset-small-lib
     ```
 
 2. Add the `size-limit` section and the `size` script to your `package.json`:
@@ -369,7 +364,7 @@ for this preset.
 4. If your project size starts to look bloated, run `--why` for analysis:
 
     ```sh
-    $ npm run size -- --why
+    npm run size -- --why
     ```
 
     > We use [Statoscope](https://github.com/statoscope/statoscope) as bundle analyzer.
@@ -418,7 +413,6 @@ for this preset.
 [Nano ID]: https://github.com/ai/nanoid/
 [React]: https://github.com/facebook/react/
 
-
 ## Reports
 
 Size Limit has a [GitHub action] that comments and rejects pull requests based
@@ -444,7 +438,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
-
 
 ## Config
 
@@ -479,10 +472,9 @@ Plugin presets:
 
 [`dual-publish`]: https://github.com/ai/dual-publish
 
-
 #### Third-Party Plugins
 
-Third-party plugins and presets named start with `size-limit-` are also supported.
+Third-party plugins and presets named starting with `size-limit-` are also supported.
 For example:
 
 * [`size-limit-node-esbuild`](https://github.com/un-ts/size-limit/tree/main/packages/node-esbuild)
@@ -490,7 +482,6 @@ For example:
 * [`size-limit-preset-node-lib`](https://github.com/un-ts/size-limit/tree/main/packages/preset-node-lib)
   is like `@size-limit/preset-small-lib` but for Node libraries which contains
   above `node-esbuild` and core `file` plugins.
-
 
 ### Limits Config
 
@@ -568,7 +559,6 @@ inserts `style-loader` runtime (≈2 kB) into the bundle.
 
 [Statoscope docs]: https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin#optionsreports-report
 [pattern]: https://github.com/sindresorhus/globby#globbing-patterns
-
 
 ## JS API
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ for this preset.
 
     > We use [Statoscope](https://github.com/statoscope/statoscope) as bundle analyzer.
 
-6. Now, let’s set the limit. Determine the current size of your library,
+5. Now, let’s set the limit. Determine the current size of your library,
    add just a little bit (a kilobyte, maybe) and use that as the limit
    in your `package.json`:
 
@@ -382,7 +382,7 @@ for this preset.
      ],
     ```
 
-7. Add the `size` script to your test suite:
+6. Add the `size` script to your test suite:
 
     ```diff
       "scripts": {
@@ -392,9 +392,9 @@ for this preset.
       }
     ```
 
-8. If you don’t have a continuous integration service running, don’t forget
+7. If you don’t have a continuous integration service running, don’t forget
    to add one — start with [Travis CI].
-9. Add the library size to docs, it will help users to choose your project:
+8. Add the library size to docs, it will help users to choose your project:
 
     ```diff
       # Project Name


### PR DESCRIPTION
I've fixed a few minor things in the README. Here is a list:

1. Unnecessary double newlines.
2. English error:
"Third-party plugins and presets named start***ING*** with `size-limit-` are also supported"
3. List went 1, 2, 3, 4, 6, 7, 8, 9. Bumped back 6, 7, 8, and 9. There are 8 items in the list.
4. In markdown when displaying shell commands, the `$` should only be present when the result of the command is displayed right below within the same block. If it's just the command alone, the `$` should be omitted.