### PR TITLE
fix: prevent spinner output while --silent

### DIFF
--- a/packages/size-limit/run.js
+++ b/packages/size-limit/run.js
@@ -74,7 +74,7 @@ module.exports = async process => {
     config = await getConfig(plugins, process, args, pkg)
 
     let calcAndShow = async () => {
-      let outputFunc = isJsonOutput ? null : createSpinner
+      let outputFunc = isJsonOutput || isSilentMode ? null : createSpinner
       await calc(plugins, config, outputFunc)
       debug.results(process, args, config)
       reporter.results(plugins, config)


### PR DESCRIPTION
Prevent messages like: `✔ Adding to empty esbuild project` while enabled silent mode