### PR TITLE
@size-limit/webpack-why: add webpack to peers

### DIFF
--- a/packages/webpack-why/package.json
+++ b/packages/webpack-why/package.json
@@ -17,7 +17,8 @@
     "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
   },
   "peerDependencies": {
-    "size-limit": "8.1.2"
+    "size-limit": "8.1.2",
+    "webpack": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@statoscope/webpack-plugin": "^5.24.0"


### PR DESCRIPTION
Add webpack to peer-deps / Cascade the requirement from @statoscope/webpack-plugin.

Same range as statoscope 

https://github.com/statoscope/statoscope/blob/42ec9ffff9688d6ec55abec9e05922b0d45e241c/packages/webpack-plugin/package.json#L37-L39


Helps to keep the install clean from warnings. 

```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @size-limit/webpack-why@npm:8.1.2 [7d865] doesn't provide webpack (p8195f), requested by @statoscope/webpack-plugin
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 259ms

```

BTW. Thanks for size-limit :pray: 

