### PR TITLE
chore: loose strictness of peer dependency requirement of `tslib`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4876,7 +4876,7 @@ packages:
     dependencies:
       '@size-limit/esbuild': 8.2.4(size-limit@packages+size-limit)
       nanoid: 3.3.6
-      tslib: 2.5.0
+      tslib: 2.5.3
     transitivePeerDependencies:
       - size-limit
     dev: true
@@ -5150,8 +5150,8 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tslib@2.5.0:
-    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+  /tslib@2.5.3:
+    resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
     dev: true
 
   /type-check@0.4.0:


### PR DESCRIPTION
Still no clue where the peer dependency requirement comes from, I don't see it defined in either `size-limit-node-esbuild` or `size-limit` itself.

Now users could update to `tslib` 2.5.3 at least to satisfy and match the dependency requirement.

Closes https://github.com/ai/size-limit/issues/326

***

- re-install `size-limit-node-esbuild` to refresh `tslib` from 2.5.0 to 2.5.3