### PR TITLE
Add support for webpack config defined as function

### DIFF
--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -48,6 +48,10 @@ async function isDirNotEmpty(dir) {
   }
 }
 
+async function loadConfig(config) {
+  return typeof config === 'function' ? config() : config
+}
+
 export default [
   {
     async before(config) {
@@ -78,7 +82,8 @@ export default [
         check.webpackOutput = join(tmpdir(), `size-limit-${nanoid()}`)
       }
       if (check.config) {
-        check.webpackConfig = (await import(check.config)).default
+        let configModule = await import(check.config)
+        check.webpackConfig = await loadConfig(configModule.default)
         convertConfig(check.webpackConfig, config.configPath)
       } else {
         check.webpackConfig = await getConfig(

--- a/packages/webpack/test/fixtures/cjs/webpack-func.config.js
+++ b/packages/webpack/test/fixtures/cjs/webpack-func.config.js
@@ -1,0 +1,12 @@
+import path from 'node:path'
+
+module.exports = (argv, env) => ({
+  entry: {
+    file: path.join(__dirname, 'file.js'),
+    small: path.join(__dirname, 'small.js')
+  },
+  output: {
+    filename: '[name].js'
+  },
+  mode: 'development'
+})

--- a/packages/webpack/test/fixtures/cjs/webpack-promise.config.js
+++ b/packages/webpack/test/fixtures/cjs/webpack-promise.config.js
@@ -1,0 +1,12 @@
+import path from 'node:path'
+
+module.exports = async (argv, env) => ({
+  entry: {
+    file: path.join(__dirname, 'file.js'),
+    small: path.join(__dirname, 'small.js')
+  },
+  output: {
+    filename: '[name].js'
+  },
+  mode: 'development'
+})

--- a/packages/webpack/test/fixtures/esm/webpack-func.config.js
+++ b/packages/webpack/test/fixtures/esm/webpack-func.config.js
@@ -1,0 +1,12 @@
+import path from 'node:path'
+
+export default (argv, env) => ({
+  entry: {
+    file: path.join(__dirname, 'file.js'),
+    small: path.join(__dirname, 'small.js')
+  },
+  output: {
+    filename: '[name].js'
+  },
+  mode: 'development'
+})

--- a/packages/webpack/test/fixtures/esm/webpack-promise.config.js
+++ b/packages/webpack/test/fixtures/esm/webpack-promise.config.js
@@ -1,0 +1,12 @@
+import path from 'node:path'
+
+export default async (argv, env) => ({
+  entry: {
+    file: path.join(__dirname, 'file.js'),
+    small: path.join(__dirname, 'small.js')
+  },
+  output: {
+    filename: '[name].js'
+  },
+  mode: 'development'
+})

--- a/packages/webpack/test/index.test.js
+++ b/packages/webpack/test/index.test.js
@@ -90,6 +90,46 @@ describe('supports custom webpack config', () => {
   })
 })
 
+describe('supports custom webpack config defined as function', () => {
+  it('works with cjs', async () => {
+    let config = {
+      checks: [{ config: fixture('cjs/webpack-func.config.js') }],
+      configPath: ROOT_CONFIG
+    }
+    await run(config)
+    expect(config.checks[0].size).toBe(1160)
+  })
+
+  it('works with esm', async () => {
+    let config = {
+      checks: [{ config: fixture('esm/webpack-func.config.js') }],
+      configPath: ROOT_CONFIG
+    }
+    await run(config)
+    expect(config.checks[0].size).toBe(1605)
+  })
+})
+
+describe('supports custom webpack config defined as async function', () => {
+  it('works with cjs', async () => {
+    let config = {
+      checks: [{ config: fixture('cjs/webpack-promise.config.js') }],
+      configPath: ROOT_CONFIG
+    }
+    await run(config)
+    expect(config.checks[0].size).toBe(1160)
+  })
+
+  it('works with esm', async () => {
+    let config = {
+      checks: [{ config: fixture('esm/webpack-promise.config.js') }],
+      configPath: ROOT_CONFIG
+    }
+    await run(config)
+    expect(config.checks[0].size).toBe(1605)
+  })
+})
+
 describe('supports custom entry', () => {
   it('works with commonjs config', async () => {
     let config = {


### PR DESCRIPTION
Fixes issue #315 

- [x] Added support for custom webpack config defined as function
- [x] Added support for custom webpack config defined as promise
- [x] Added tests for both cases
  - [x] cjs config
  - [x] esm config

The `loadConfig` function is deliberately made async, so:
1. If the custom webpack config function returns a promise — it is resolved and the result is passed to webpack.
2. If the custom webpack config is an object, or it is a synchronous function — the await statement has no effect and the resulting object is passed as is. 