### PR TITLE
fix(@size-limit/webpack-css  v10.0.1 ): require is not defined in ES module scope when running size-limit

### DIFF
--- a/fixtures/zero-esbuild/package.json
+++ b/fixtures/zero-esbuild/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@size-limit/esbuild": ">= 0.0.0",
     "@size-limit/file": ">= 0.0.0",
+    "@size-limit/webpack-css": ">= 10.0.1",
     "size-limit": ">= 0.0.0"
   },
   "size-limit": [

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@size-limit/preset-small-lib": "workspace:^",
     "@size-limit/time": "workspace:^",
     "@size-limit/webpack": "workspace:^",
+    "@size-limit/webpack-css": "workspace:^",
     "@size-limit/webpack-why": "workspace:^",
     "@vitest/coverage-v8": "^0.34.6",
     "clean-publish": "^4.2.0",

--- a/packages/size-limit/test/load-plugins.test.js
+++ b/packages/size-limit/test/load-plugins.test.js
@@ -9,9 +9,10 @@ describe(`load-plugins`, () => {
     let cwd = join(__dirname, '..', '..', '..', 'fixtures', 'zero-esbuild')
     let result = await loadPlugins(await readPkgUp(cwd))
     expect(result.isEmpty).toBe(false)
-    expect(result.list.length).toBe(2)
+    expect(result.list.length).toBe(3)
     expect(result.has('esbuild')).toBe(true)
     expect(result.has('file')).toBe(true)
+    expect(result.has('webpack-css')).toBe(true)
     expect(result.has('plugin')).toBe(false)
   })
 

--- a/packages/webpack-css/index.js
+++ b/packages/webpack-css/index.js
@@ -1,4 +1,7 @@
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin'
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 const cssRule = {
   exclude: /\.module\.css$/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@size-limit/webpack':
         specifier: workspace:^
         version: link:packages/webpack
+      '@size-limit/webpack-css':
+        specifier: workspace:^
+        version: link:packages/webpack-css
       '@size-limit/webpack-why':
         specifier: workspace:^
         version: link:packages/webpack-why


### PR DESCRIPTION
Good day! Thank you very much for this amazing tool!

## Problem
In our project we are using `size-limit` with` @size-limit/webpack-css` plugin and with latest version `v10.0.1` we are having an issue and see this error running `size-limit`.
```
ReferenceError: require is not defined in ES module scope, you can use import instead\nThis file is being treated as an ES module because it has a '.js' file extension
```

<details>
<summary>The whole error</summary>

```
{
  "error": "ReferenceError: require is not defined in ES module scope, you can use import instead\nThis file is being treated as an ES module because it has a '.js' file extension and '/Users/andrey.medvedev/src/experiment
/size-limit-experiment/node_modules/@size-limit/webpack-css/package.json' contains \"type\": \"module\". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.\n    at file:///Users/andrey.medvedev/s
rc/experiment/size-limit-experiment/node_modules/@size-limit/webpack-css/index.js:6:9\n    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)\n    at async Promise.all (index 0)\n    at async ESMLoader.import (
node:internal/modules/esm/loader:528:24)\n    at async Promise.all (index 2)\n    at async loadPlugins (file:///Users/andrey.medvedev/src/experiment/size-limit-experiment/node_modules/size-limit/load-plugins.js:24:14)\n
 at async findPlugins (file:///Users/andrey.medvedev/src/experiment/size-limit-experiment/node_modules/size-limit/run.js:28:17)\n    at async default (file:///Users/andrey.medvedev/src/experiment/size-limit-experiment/node_modules/size-limit/run.js:57:19)"
}
```
</details>

## Version
size-limit: v10.0.1
node: v18.8.0.

## To reproduce
Here is a repo example with reproduction:  https://github.com/mendrew/stunning-journey

## Proposal

As a solution we use `createRequire` to require commonjs from esm module like we do here in `size-limit` in other modules. Works well in my case. Hope it close to a solution.

### Changes
- use createRequire inside webpack-css plugin
- adding webpack-css plugin as a workspace to global workspace package.json.
- checking that load-plugins() is not throwing an error when we load webpack-css (https://github.com/mendrew/size-limit/blob/f9e9a78c3f62be7061bfd25efa7e546f02de549c/packages/size-limit/test/load-plugins.test.js#L8-L16)

## Notes
Unfortunately I was not able to reproduce this issue in tests. Any ideas where I can put a test which would be similar to the [example with reproduction](https://github.com/mendrew/stunning-journey/blob/main/package.json#L10-L15)?
`load-plugins.test.js` doesn't catch this issue.