### PR TITLE
fix: use dynamic `import` directly without `require.resolve`

### DIFF
--- a/packages/size-limit/load-plugins.js
+++ b/packages/size-limit/load-plugins.js
@@ -1,6 +1,3 @@
-import { createRequire } from 'node:module'
-const require = createRequire(import.meta.url)
-
 function toArray(obj) {
   return typeof obj === 'object' ? Object.keys(obj) : []
 }
@@ -26,13 +23,7 @@ export default async function loadPlugins(pkg) {
       .concat(toArray(pkg.packageJson.devDependencies))
       .concat(toArray(pkg.packageJson.optionalDependencies))
       .filter(i => i.startsWith('@size-limit/') || i.startsWith('size-limit-'))
-      .map(i =>
-        import(
-          require.resolve(i, {
-            paths: [process.cwd()]
-          })
-        ).then(module => module.default)
-      )
+      .map(i => import(i).then(module => module.default))
   ).then(arr => arr.flat())
 
   return new Plugins(list)


### PR DESCRIPTION
close #336
close #344