### PR TITLE
Add support `.mjs` config files

### DIFF
--- a/fixtures/js-config-file-with-type-module/.size-limit.js
+++ b/fixtures/js-config-file-with-type-module/.size-limit.js
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/js-config-file-with-type-module/index.js
+++ b/fixtures/js-config-file-with-type-module/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/js-config-file-with-type-module/package.json
+++ b/fixtures/js-config-file-with-type-module/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "js-config-file-with-type-module",
+  "type": "module",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/js-config-file/.size-limit.js
+++ b/fixtures/js-config-file/.size-limit.js
@@ -1,5 +1,5 @@
 module.exports = [
   {
-    path: 'index.js',
+    path: 'index.js'
   }
 ]

--- a/fixtures/js-config-file/.size-limit.js
+++ b/fixtures/js-config-file/.size-limit.js
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js',
+  }
+]

--- a/fixtures/js-config-file/index.js
+++ b/fixtures/js-config-file/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/js-config-file/package.json
+++ b/fixtures/js-config-file/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "js-config-file",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/mjs-config-file/.size-limit.mjs
+++ b/fixtures/mjs-config-file/.size-limit.mjs
@@ -1,5 +1,5 @@
 export default [
   {
-    path: 'index.js',
+    path: 'index.js'
   }
 ]

--- a/fixtures/mjs-config-file/.size-limit.mjs
+++ b/fixtures/mjs-config-file/.size-limit.mjs
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js',
+  }
+]

--- a/fixtures/mjs-config-file/index.js
+++ b/fixtures/mjs-config-file/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/mjs-config-file/package.json
+++ b/fixtures/mjs-config-file/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "mjs-config-file",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -82,6 +82,15 @@ function toName(files, cwd) {
   return files.map(i => (i.startsWith(cwd) ? relative(cwd, i) : i)).join(', ')
 }
 
+/**
+ * Dynamically imports a module from a given file path
+ * and returns its default export.
+ *
+ * @param {string} filePath - The path to the module file to be imported.
+ * @returns {Promise<any>} A promise that resolves with the default export of the module.
+ */
+const dynamicImport = async filePath => (await import(filePath)).default
+
 export default async function getConfig(plugins, process, args, pkg) {
   let config = {
     cwd: process.cwd()
@@ -113,7 +122,8 @@ export default async function getConfig(plugins, process, args, pkg) {
   } else {
     let explorer = lilconfig('size-limit', {
       loaders: {
-        '.mjs': async filePath => (await import(filePath)).default
+        '.js': dynamicImport,
+        '.mjs': dynamicImport
       },
       searchPlaces: [
         'package.json',

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -112,11 +112,15 @@ export default async function getConfig(plugins, process, args, pkg) {
     config.checks = [{ files: args.files }]
   } else {
     let explorer = lilconfig('size-limit', {
+      loaders: {
+        '.mjs': async filePath => (await import(filePath)).default
+      },
       searchPlaces: [
         'package.json',
         '.size-limit.json',
         '.size-limit',
         '.size-limit.js',
+        '.size-limit.mjs',
         '.size-limit.cjs'
       ]
     })

--- a/packages/size-limit/package.json
+++ b/packages/size-limit/package.json
@@ -26,7 +26,7 @@
     "bytes-iec": "^3.1.1",
     "chokidar": "^3.5.3",
     "globby": "^14.0.0",
-    "lilconfig": "^3.0.0",
+    "lilconfig": "^3.1.1",
     "nanospinner": "^1.1.0",
     "picocolors": "^1.0.0"
   },

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -195,6 +195,34 @@ it('normalizes bundle and webpack arguments with --why and ui-reports', async ()
   })
 })
 
+it('should work with .mjs config file', async () => {
+  expect(await check('mjs-config-file')).toEqual({
+    checks: [
+      {
+        files: [fixture('mjs-config-file', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.mjs',
+    cwd: fixture('mjs-config-file')
+  })
+})
+
+it('should work with .js config file', async () => {
+  expect(await check('js-config-file')).toEqual({
+    checks: [
+      {
+        files: [fixture('js-config-file', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.js',
+    cwd: fixture('js-config-file')
+  })
+})
+
 it('uses peerDependencies as ignore option', async () => {
   expect(await check('peer')).toEqual({
     checks: [

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -223,6 +223,20 @@ it('should work with .js config file', async () => {
   })
 })
 
+it('should work with .js config file and "type": "module"', async () => {
+  expect(await check('js-config-file-with-type-module')).toEqual({
+    checks: [
+      {
+        files: [fixture('js-config-file-with-type-module', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.js',
+    cwd: fixture('js-config-file-with-type-module')
+  })
+})
+
 it('uses peerDependencies as ignore option', async () => {
   expect(await check('peer')).toEqual({
     checks: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         version: 1.0.2(eslint@8.56.0)
       eslint-plugin-perfectionist:
         specifier: ^2.5.0
-        version: 2.5.0(eslint@8.56.0)(typescript@5.3.3)
+        version: 2.5.0(eslint@8.56.0)(typescript@5.4.2)
       eslint-plugin-prefer-let:
         specifier: ^3.0.1
         version: 3.0.1
@@ -188,8 +188,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       lilconfig:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.1.1
+        version: 3.1.1
       nanospinner:
         specifier: ^1.1.0
         version: 1.1.0
@@ -662,7 +662,7 @@ packages:
       eslint-plugin-import: 2.29.1(eslint@8.56.0)
       eslint-plugin-n: 16.6.2(eslint@8.56.0)
       eslint-plugin-node-import: 1.0.4(eslint@8.56.0)
-      eslint-plugin-perfectionist: 2.5.0(eslint@8.56.0)(typescript@5.3.3)
+      eslint-plugin-perfectionist: 2.5.0(eslint@8.56.0)(typescript@5.4.2)
       eslint-plugin-prefer-let: 3.0.1
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
     dev: true
@@ -1110,7 +1110,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.19.0(typescript@5.3.3):
+  /@typescript-eslint/typescript-estree@6.19.0(typescript@5.4.2):
     resolution: {integrity: sha512-o/zefXIbbLBZ8YJ51NlkSAt2BamrK6XOmuxSR3hynMIzzyMY33KuJ9vuMdFSXW+H0tVvdF9qBPTHA91HDb4BIQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1126,13 +1126,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
-      typescript: 5.3.3
+      ts-api-utils: 1.0.3(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.19.0(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/utils@6.19.0(eslint@8.56.0)(typescript@5.4.2):
     resolution: {integrity: sha512-QR41YXySiuN++/dC9UArYOg4X86OAYP83OWTewpVx5ct1IZhjjgTLocj7QNxGhWoTqknsgpl7L+hGygCO+sdYw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1143,7 +1143,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.19.0
       '@typescript-eslint/types': 6.19.0
-      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.4.2)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -1922,7 +1922,7 @@ packages:
       postcss: ^8.4.31
     dependencies:
       cssnano-preset-default: 6.0.3(postcss@8.4.33)
-      lilconfig: 3.0.0
+      lilconfig: 3.1.1
       postcss: 8.4.33
     dev: false
 
@@ -2385,7 +2385,7 @@ packages:
       eslint: 8.56.0
     dev: true
 
-  /eslint-plugin-perfectionist@2.5.0(eslint@8.56.0)(typescript@5.3.3):
+  /eslint-plugin-perfectionist@2.5.0(eslint@8.56.0)(typescript@5.4.2):
     resolution: {integrity: sha512-F6XXcq4mKKUe/SREoMGQqzgw6cgCgf3pFzkFfQVIGtqD1yXVpQjnhTepzhBeZfxZwgMzR9HO4yH4CUhIQ2WBcQ==}
     peerDependencies:
       astro-eslint-parser: ^0.16.0
@@ -2403,7 +2403,7 @@ packages:
       vue-eslint-parser:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.4.2)
       eslint: 8.56.0
       minimatch: 9.0.3
       natural-compare-lite: 1.4.0
@@ -3290,8 +3290,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /lilconfig@3.0.0:
-    resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
+  /lilconfig@3.1.1:
+    resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
     engines: {node: '>=14'}
     dev: false
 
@@ -4666,13 +4666,13 @@ packages:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
 
-  /ts-api-utils@1.0.3(typescript@5.3.3):
+  /ts-api-utils@1.0.3(typescript@5.4.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.3.3
+      typescript: 5.4.2
     dev: true
 
   /tsconfig-paths@3.15.0:
@@ -4742,8 +4742,8 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
-  /typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
## This PR:

  - [X] Adds support `.mjs` config files.
  - [X] Adds support for `.js` config files with the nearest `package.json` having `"type": "module"`.
  - [X] Bumps `lilconfig` to latest version.
  - [X] Adds unit tests to test different types of config files.
  - [X] Resolves #352.