### PR TITLE
Add support for TypeScript config files (`.size-limit.ts`, `.size-limit.mts`, `.size-limit.cts`)

### DIFF
--- a/fixtures/cjs-config-file-cjs/.size-limit.cjs
+++ b/fixtures/cjs-config-file-cjs/.size-limit.cjs
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/cjs-config-file-cjs/index.js
+++ b/fixtures/cjs-config-file-cjs/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/cjs-config-file-cjs/package.json
+++ b/fixtures/cjs-config-file-cjs/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "cjs-config-file-cjs",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/cjs-config-file-esm/.size-limit.cjs
+++ b/fixtures/cjs-config-file-esm/.size-limit.cjs
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/cjs-config-file-esm/index.js
+++ b/fixtures/cjs-config-file-esm/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/cjs-config-file-esm/package.json
+++ b/fixtures/cjs-config-file-esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "cjs-config-file-esm",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/cts-config-file-cjs/.size-limit.cts
+++ b/fixtures/cts-config-file-cjs/.size-limit.cts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 module.exports = [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/cts-config-file-cjs/.size-limit.cts
+++ b/fixtures/cts-config-file-cjs/.size-limit.cts
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/cts-config-file-cjs/index.js
+++ b/fixtures/cts-config-file-cjs/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/cts-config-file-cjs/package.json
+++ b/fixtures/cts-config-file-cjs/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "cts-config-file-cjs",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/cts-config-file-esm/.size-limit.cts
+++ b/fixtures/cts-config-file-esm/.size-limit.cts
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/cts-config-file-esm/.size-limit.cts
+++ b/fixtures/cts-config-file-esm/.size-limit.cts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 export default [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/cts-config-file-esm/index.js
+++ b/fixtures/cts-config-file-esm/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/cts-config-file-esm/package.json
+++ b/fixtures/cts-config-file-esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "cts-config-file-esm",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/cts-config-file/.size-limit.cts
+++ b/fixtures/cts-config-file/.size-limit.cts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 module.exports = [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/cts-config-file/.size-limit.cts
+++ b/fixtures/cts-config-file/.size-limit.cts
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/cts-config-file/index.js
+++ b/fixtures/cts-config-file/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/cts-config-file/package.json
+++ b/fixtures/cts-config-file/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "cts-config-file",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/js-config-file-cjs/.size-limit.js
+++ b/fixtures/js-config-file-cjs/.size-limit.js
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/js-config-file-cjs/index.js
+++ b/fixtures/js-config-file-cjs/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/js-config-file-cjs/package.json
+++ b/fixtures/js-config-file-cjs/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "js-config-file-cjs",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/js-config-file-esm/.size-limit.js
+++ b/fixtures/js-config-file-esm/.size-limit.js
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/js-config-file-esm/index.js
+++ b/fixtures/js-config-file-esm/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/js-config-file-esm/package.json
+++ b/fixtures/js-config-file-esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "js-config-file-esm",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/mjs-config-file-cjs/.size-limit.mjs
+++ b/fixtures/mjs-config-file-cjs/.size-limit.mjs
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/mjs-config-file-cjs/index.js
+++ b/fixtures/mjs-config-file-cjs/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/mjs-config-file-cjs/package.json
+++ b/fixtures/mjs-config-file-cjs/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "mjs-config-file-cjs",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/mjs-config-file-esm/.size-limit.mjs
+++ b/fixtures/mjs-config-file-esm/.size-limit.mjs
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/mjs-config-file-esm/index.js
+++ b/fixtures/mjs-config-file-esm/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/mjs-config-file-esm/package.json
+++ b/fixtures/mjs-config-file-esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "mjs-config-file-esm",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/mts-config-file-cjs/.size-limit.mts
+++ b/fixtures/mts-config-file-cjs/.size-limit.mts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 module.exports = [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/mts-config-file-cjs/.size-limit.mts
+++ b/fixtures/mts-config-file-cjs/.size-limit.mts
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/mts-config-file-cjs/index.js
+++ b/fixtures/mts-config-file-cjs/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/mts-config-file-cjs/package.json
+++ b/fixtures/mts-config-file-cjs/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "mts-config-file-cjs",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/mts-config-file-esm/.size-limit.mts
+++ b/fixtures/mts-config-file-esm/.size-limit.mts
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/mts-config-file-esm/.size-limit.mts
+++ b/fixtures/mts-config-file-esm/.size-limit.mts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 export default [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/mts-config-file-esm/index.js
+++ b/fixtures/mts-config-file-esm/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/mts-config-file-esm/package.json
+++ b/fixtures/mts-config-file-esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "mts-config-file-esm",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/mts-config-file/.size-limit.mts
+++ b/fixtures/mts-config-file/.size-limit.mts
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/mts-config-file/.size-limit.mts
+++ b/fixtures/mts-config-file/.size-limit.mts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 export default [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/mts-config-file/index.js
+++ b/fixtures/mts-config-file/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/mts-config-file/package.json
+++ b/fixtures/mts-config-file/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "mts-config-file",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/ts-config-file-cjs/.size-limit.ts
+++ b/fixtures/ts-config-file-cjs/.size-limit.ts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 module.exports = [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/ts-config-file-cjs/.size-limit.ts
+++ b/fixtures/ts-config-file-cjs/.size-limit.ts
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/ts-config-file-cjs/index.js
+++ b/fixtures/ts-config-file-cjs/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/ts-config-file-cjs/package.json
+++ b/fixtures/ts-config-file-cjs/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "ts-config-file-cjs",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/ts-config-file-esm/.size-limit.ts
+++ b/fixtures/ts-config-file-esm/.size-limit.ts
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/ts-config-file-esm/.size-limit.ts
+++ b/fixtures/ts-config-file-esm/.size-limit.ts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 export default [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/ts-config-file-esm/index.js
+++ b/fixtures/ts-config-file-esm/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/ts-config-file-esm/package.json
+++ b/fixtures/ts-config-file-esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "ts-config-file-esm",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/ts-config-file-with-type-module/.size-limit.ts
+++ b/fixtures/ts-config-file-with-type-module/.size-limit.ts
@@ -1,0 +1,5 @@
+export default [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/ts-config-file-with-type-module/.size-limit.ts
+++ b/fixtures/ts-config-file-with-type-module/.size-limit.ts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 export default [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/ts-config-file-with-type-module/index.js
+++ b/fixtures/ts-config-file-with-type-module/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/ts-config-file-with-type-module/package.json
+++ b/fixtures/ts-config-file-with-type-module/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "ts-config-file-with-type-module",
+  "type": "module",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/ts-config-file/.size-limit.ts
+++ b/fixtures/ts-config-file/.size-limit.ts
@@ -1,5 +1,7 @@
+import { SizeLimitConfig } from '../../packages/size-limit'
+
 module.exports = [
   {
     path: 'index.js'
   }
-]
+] satisfies SizeLimitConfig

--- a/fixtures/ts-config-file/.size-limit.ts
+++ b/fixtures/ts-config-file/.size-limit.ts
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    path: 'index.js'
+  }
+]

--- a/fixtures/ts-config-file/index.js
+++ b/fixtures/ts-config-file/index.js
@@ -1,0 +1,5 @@
+const first = 'first'
+
+const second = 'second'
+
+export { first, second }

--- a/fixtures/ts-config-file/package.json
+++ b/fixtures/ts-config-file/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "ts-config-file",
+  "devDependencies": {
+    "@size-limit/webpack": ">= 0.0.0",
+    "@size-limit/webpack-why": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -5,6 +5,7 @@ import { lilconfig } from 'lilconfig'
 import { createRequire } from 'node:module'
 import { dirname, isAbsolute, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import { SizeLimitError } from './size-limit-error.js'
 
 const require = createRequire(import.meta.url)

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -103,7 +103,7 @@ const dynamicImport = async filePath => (await import(filePath)).default
  * @returns {Promise<any>} The module exports from the loaded TypeScript file.
  */
 const tsLoader = async filePath => {
-  const jiti = (await import('jiti')).default(fileURLToPath(import.meta.url), {
+  let jiti = (await import('jiti')).default(fileURLToPath(import.meta.url), {
     interopDefault: true
   })
   return jiti(filePath)

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -1,6 +1,5 @@
 import bytes from 'bytes-iec'
 import { globby } from 'globby'
-import buildJiti from 'jiti'
 import { lilconfig } from 'lilconfig'
 import { createRequire } from 'node:module'
 import { dirname, isAbsolute, join, relative } from 'node:path'
@@ -9,8 +8,6 @@ import { fileURLToPath } from 'node:url'
 import { SizeLimitError } from './size-limit-error.js'
 
 const require = createRequire(import.meta.url)
-
-const jiti = buildJiti(fileURLToPath(import.meta.url), { interopDefault: true })
 
 let OPTIONS = {
   brotli: 'file',
@@ -103,9 +100,14 @@ const dynamicImport = async filePath => (await import(filePath)).default
  * without pre-compilation.
  *
  * @param {string} filePath - The path to the TypeScript file to be loaded.
- * @returns {any} The module exports from the loaded TypeScript file.
+ * @returns {Promise<any>} The module exports from the loaded TypeScript file.
  */
-const tsLoader = filePath => jiti(filePath)
+const tsLoader = async filePath => {
+  const jiti = (await import('jiti')).default(fileURLToPath(import.meta.url), {
+    interopDefault: true
+  })
+  return jiti(filePath)
+}
 
 export default async function getConfig(plugins, process, args, pkg) {
   let config = {

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -9,9 +9,7 @@ import { SizeLimitError } from './size-limit-error.js'
 
 const require = createRequire(import.meta.url)
 
-const __filename = fileURLToPath(import.meta.url)
-
-const jiti = buildJiti(__filename, { interopDefault: true })
+const jiti = buildJiti(fileURLToPath(import.meta.url), { interopDefault: true })
 
 let OPTIONS = {
   brotli: 'file',
@@ -139,12 +137,12 @@ export default async function getConfig(plugins, process, args, pkg) {
   } else {
     let explorer = lilconfig('size-limit', {
       loaders: {
+        '.cjs': dynamicImport,
+        '.cts': tsLoader,
         '.js': dynamicImport,
         '.mjs': dynamicImport,
-        '.cjs': dynamicImport,
-        '.ts': tsLoader,
         '.mts': tsLoader,
-        '.cts': tsLoader
+        '.ts': tsLoader
       },
       searchPlaces: [
         'package.json',

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -1,6 +1,6 @@
 import bytes from 'bytes-iec'
 import { globby } from 'globby'
-import _jiti from 'jiti'
+import buildJiti from 'jiti'
 import { lilconfig } from 'lilconfig'
 import { createRequire } from 'node:module'
 import { dirname, isAbsolute, join, relative } from 'node:path'
@@ -11,7 +11,7 @@ const require = createRequire(import.meta.url)
 
 const __filename = fileURLToPath(import.meta.url)
 
-const jiti = _jiti(__filename, { interopDefault: true })
+const jiti = buildJiti(__filename, { interopDefault: true })
 
 let OPTIONS = {
   brotli: 'file',

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -4,10 +4,13 @@ import _jiti from 'jiti'
 import { lilconfig } from 'lilconfig'
 import { createRequire } from 'node:module'
 import { dirname, isAbsolute, join, relative } from 'node:path'
-
+import { fileURLToPath } from 'node:url'
 import { SizeLimitError } from './size-limit-error.js'
 
 const require = createRequire(import.meta.url)
+
+const __filename = fileURLToPath(import.meta.url)
+
 const jiti = _jiti(__filename, { interopDefault: true })
 
 let OPTIONS = {

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -1,3 +1,6 @@
+/**
+ * Represents the options for the size-limit check.
+ */
 export interface Check {
   /**
    * With `false` it will disable any compression.

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -1,4 +1,4 @@
-export interface Config {
+export interface Check {
   /**
    * With `false` it will disable any compression.
    */
@@ -89,4 +89,4 @@ export interface Config {
   webpack?: boolean
 }
 
-export type SizeLimitConfig = Config[]
+export type SizeLimitConfig = Check[]

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -1,21 +1,90 @@
 export type Config = {
+  /**
+   * With `false` it will disable any compression.
+   */
   brotli?: boolean
+
+  /**
+   * Path to `stats.json` from another build to compare (when `--why` is using).
+   */
   compareWith?: string
+
+  /**
+   * A path to a custom webpack config.
+   */
   config?: string
   disableModuleConcatenation?: boolean
+
+  /**
+   * When using a custom webpack config, a webpack entry could be given.
+   * It could be a string or an array of strings. By default,
+   * the total size of all entry points will be checked.
+   */
   entry?: string | string[]
+
+  /**
+   * With `true` it will use Gzip compression and disable Brotli compression.
+   */
   gzip?: boolean
   hidePassed?: boolean
   highlightLess?: boolean
+
+  /**
+   * An array of files and dependencies to exclude from
+   * the project size calculation.
+   */
   ignore?: string[]
+  /**
+   * Partial import to test tree-shaking. It could be `"{ lib }"` to test
+   * `import { lib } from 'lib'`, `*` to test all exports, or
+   * `{ "a.js": "{ a }", "b.js": "{ b }" }` to test multiple files.
+   */
   import?: string | Record<string, string>
+
+  /**
+   * Size or time limit for files from the path option.
+   * It should be a string with a number and unit, separated by a space.
+   * Format: `100 B`, `10 kB`, `500 ms`, `1 s`.
+   */
   limit?: string
   modifyEsbuildConfig?: (config?: any) => any
+
+  /**
+   * (`.size-limit.js` only) Function that can be used to do last-minute
+   * changes to the webpack config, like adding a plugin.
+   */
   modifyWebpackConfig?: (config?: any) => any
   module?: boolean
+
+  /**
+   * The name of the current section.
+   * It will only be useful if you have multiple sections.
+   */
   name?: string
+
+  /**
+   * Relative paths to files. The only mandatory option.
+   * It could be a path `"index.js"`, a
+   * {@link https://github.com/sindresorhus/globby#globbing-patterns pattern}
+   * `"dist/app-*.js"` or an array
+   * `["index.js", "dist/app-*.js", "!dist/app-exclude.js"]`.
+   */
   path: string | string[]
+
+  /**
+   * With `false` it will disable calculating running time.
+   */
   running?: boolean
+
+  /**
+   * Custom UI reports list.
+   *
+   * @see {@link https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin#optionsreports-report Statoscope docs}
+   */
   uiReports?: object
+
+  /**
+   * With `false` it will disable webpack.
+   */
   webpack?: boolean
 }

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -1,0 +1,21 @@
+export type Config = {
+  brotli?: boolean
+  compareWith?: string
+  config?: string
+  disableModuleConcatenation?: boolean
+  entry?: string | string[]
+  gzip?: boolean
+  hidePassed?: boolean
+  highlightLess?: boolean
+  ignore?: string[]
+  import?: string | Record<string, string>
+  limit?: string
+  modifyEsbuildConfig?: (config?: any) => any
+  modifyWebpackConfig?: (config?: any) => any
+  module?: boolean
+  name?: string
+  path: string | string[]
+  running?: boolean
+  uiReports?: object
+  webpack?: boolean
+}

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -1,4 +1,4 @@
-export type Config = {
+export interface Config {
   /**
    * With `false` it will disable any compression.
    */

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -96,3 +96,22 @@ export interface Check {
 }
 
 export type SizeLimitConfig = Check[]
+
+/**
+ * Any function with any arguments.
+ */
+type AnyFunction = (...args: any[]) => any
+
+/**
+ * Run Size Limit and return the result.
+ *
+ * @param plugins   The list of plugins like `@size-limit/time`
+ * @param  files Path to files or internal config
+ * @return Project size
+ */
+declare function sizeLimitAPI(
+  plugins: AnyFunction,
+  files: string[] | object
+): Promise<object>
+
+export default sizeLimitAPI

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -13,6 +13,7 @@ export interface Check {
    * A path to a custom webpack config.
    */
   config?: string
+
   disableModuleConcatenation?: boolean
 
   /**
@@ -26,7 +27,9 @@ export interface Check {
    * With `true` it will use Gzip compression and disable Brotli compression.
    */
   gzip?: boolean
+
   hidePassed?: boolean
+
   highlightLess?: boolean
 
   /**
@@ -34,6 +37,7 @@ export interface Check {
    * the project size calculation.
    */
   ignore?: string[]
+
   /**
    * Partial import to test tree-shaking. It could be `"{ lib }"` to test
    * `import { lib } from 'lib'`, `*` to test all exports, or
@@ -47,6 +51,7 @@ export interface Check {
    * Format: `100 B`, `10 kB`, `500 ms`, `1 s`.
    */
   limit?: string
+
   modifyEsbuildConfig?: (config?: any) => any
 
   /**
@@ -54,6 +59,7 @@ export interface Check {
    * changes to the webpack config, like adding a plugin.
    */
   modifyWebpackConfig?: (config?: any) => any
+
   module?: boolean
 
   /**

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -88,3 +88,5 @@ export type Config = {
    */
   webpack?: boolean
 }
+
+export type SizeLimitConfig = Config[]

--- a/packages/size-limit/index.js
+++ b/packages/size-limit/index.js
@@ -8,7 +8,7 @@ export { SizeLimitError } from './size-limit-error.js'
 /**
  * Run Size Limit and return the result
  *
- * @param  {functions[]} plugins   The list of plugins like `@size-limit/time`
+ * @param  {Function[]} plugins   The list of plugins like `@size-limit/time`
  * @param  {string[]|object} files Path to files or internal config
  * @return {Promise<object>}     Project size
  */

--- a/packages/size-limit/package.json
+++ b/packages/size-limit/package.json
@@ -3,6 +3,7 @@
   "version": "11.0.3",
   "description": "CLI tool for Size Limit",
   "type": "module",
+  "types": "index.d.ts",
   "keywords": [
     "size-limit",
     "cli",

--- a/packages/size-limit/package.json
+++ b/packages/size-limit/package.json
@@ -26,6 +26,7 @@
     "bytes-iec": "^3.1.1",
     "chokidar": "^3.6.0",
     "globby": "^14.0.1",
+    "jiti": "^1.21.0",
     "lilconfig": "^3.1.1",
     "nanospinner": "^1.1.0",
     "picocolors": "^1.0.0"

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -431,8 +431,8 @@ it('normalizes import', async () => {
 
 const allConfigFileExtensions = ['mjs', 'js', 'cjs', 'ts', 'mts', 'cts']
 const exportTypes = [
-  { moduleType: 'esm', exportSyntax: 'export default' },
-  { moduleType: 'cjs', exportSyntax: 'module.exports' }
+  { exportSyntax: 'export default', moduleType: 'esm' },
+  { exportSyntax: 'module.exports', moduleType: 'cjs' }
 ]
 
 describe.each(allConfigFileExtensions)(

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -1,5 +1,5 @@
 import { join } from 'node:path'
-import { beforeEach, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import calc from '../calc'
 import run from '../run'
@@ -237,6 +237,118 @@ it('should work with .js config file and "type": "module"', async () => {
   })
 })
 
+it('should work with .js config file and `export default` without "type": "module"', async () => {
+  expect(await check('js-config-file-esm')).toEqual({
+    checks: [
+      {
+        files: [fixture('js-config-file-esm', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.js',
+    cwd: fixture('js-config-file-esm')
+  })
+})
+
+it('should work with .cjs config file and `export default` without "type": "module"', async () => {
+  expect(await check('cjs-config-file-esm')).toEqual({
+    checks: [
+      {
+        files: [fixture('cjs-config-file-esm', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.cjs',
+    cwd: fixture('cjs-config-file-esm')
+  })
+})
+
+it('should work with .cjs config file and `module.exports` without "type": "module"', async () => {
+  expect(await check('cjs-config-file-cjs')).toEqual({
+    checks: [
+      {
+        files: [fixture('cjs-config-file-cjs', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.cjs',
+    cwd: fixture('cjs-config-file-cjs')
+  })
+})
+
+it('should work with .ts config file and `export default` without "type": "module"', async () => {
+  expect(await check('ts-config-file-esm')).toEqual({
+    checks: [
+      {
+        files: [fixture('ts-config-file-esm', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.ts',
+    cwd: fixture('ts-config-file-esm')
+  })
+})
+
+it('should work with .ts config file', async () => {
+  expect(await check('ts-config-file')).toEqual({
+    checks: [
+      {
+        files: [fixture('ts-config-file', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.ts',
+    cwd: fixture('ts-config-file')
+  })
+})
+
+it('should work with .cts config file', async () => {
+  expect(await check('cts-config-file')).toEqual({
+    checks: [
+      {
+        files: [fixture('cts-config-file', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.cts',
+    cwd: fixture('cts-config-file')
+  })
+})
+
+it('should work with .mts config file', async () => {
+  expect(await check('mts-config-file')).toEqual({
+    checks: [
+      {
+        files: [fixture('mts-config-file', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.mts',
+    cwd: fixture('mts-config-file')
+  })
+})
+
+it('should work with .ts config file and "type": "module"', async () => {
+  expect(await check('ts-config-file-with-type-module')).toEqual({
+    checks: [
+      {
+        files: [fixture('ts-config-file-with-type-module', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: '.size-limit.ts',
+    cwd: fixture('ts-config-file-with-type-module')
+  })
+})
+
 it('uses peerDependencies as ignore option', async () => {
   expect(await check('peer')).toEqual({
     checks: [
@@ -316,3 +428,33 @@ it('normalizes import', async () => {
     cwd: fixture('integration-esm')
   })
 })
+
+const allConfigFileExtensions = ['mjs', 'js', 'cjs', 'ts', 'mts', 'cts']
+const exportTypes = [
+  { moduleType: 'esm', exportSyntax: 'export default' },
+  { moduleType: 'cjs', exportSyntax: 'module.exports' }
+]
+
+describe.each(allConfigFileExtensions)(
+  'config file with `.%s` extension',
+  extension => {
+    it.each(exportTypes)(
+      'should work with $moduleType module syntax ($exportSyntax)',
+      async ({ moduleType }) => {
+        expect(await check(`${extension}-config-file-${moduleType}`)).toEqual({
+          checks: [
+            {
+              files: [
+                fixture(`${extension}-config-file-${moduleType}`, 'index.js')
+              ],
+              name: 'index.js',
+              path: 'index.js'
+            }
+          ],
+          configPath: `.size-limit.${extension}`,
+          cwd: fixture(`${extension}-config-file-${moduleType}`)
+        })
+      }
+    )
+  }
+)

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -195,7 +195,7 @@ it('normalizes bundle and webpack arguments with --why and ui-reports', async ()
   })
 })
 
-it('should work with .mjs config file', async () => {
+it('works with .mjs config file', async () => {
   expect(await check('mjs-config-file')).toEqual({
     checks: [
       {
@@ -209,7 +209,7 @@ it('should work with .mjs config file', async () => {
   })
 })
 
-it('should work with .js config file', async () => {
+it('works with .js config file', async () => {
   expect(await check('js-config-file')).toEqual({
     checks: [
       {
@@ -223,7 +223,7 @@ it('should work with .js config file', async () => {
   })
 })
 
-it('should work with .js config file and "type": "module"', async () => {
+it('works with .js config file and "type": "module"', async () => {
   expect(await check('js-config-file-with-type-module')).toEqual({
     checks: [
       {
@@ -237,7 +237,7 @@ it('should work with .js config file and "type": "module"', async () => {
   })
 })
 
-it('should work with .js config file and `export default` without "type": "module"', async () => {
+it('works with .js config file and `export default` without "type": "module"', async () => {
   expect(await check('js-config-file-esm')).toEqual({
     checks: [
       {
@@ -251,7 +251,7 @@ it('should work with .js config file and `export default` without "type": "modul
   })
 })
 
-it('should work with .cjs config file and `export default` without "type": "module"', async () => {
+it('works with .cjs config file and `export default` without "type": "module"', async () => {
   expect(await check('cjs-config-file-esm')).toEqual({
     checks: [
       {
@@ -265,7 +265,7 @@ it('should work with .cjs config file and `export default` without "type": "modu
   })
 })
 
-it('should work with .cjs config file and `module.exports` without "type": "module"', async () => {
+it('works with .cjs config file and `module.exports` without "type": "module"', async () => {
   expect(await check('cjs-config-file-cjs')).toEqual({
     checks: [
       {
@@ -279,7 +279,7 @@ it('should work with .cjs config file and `module.exports` without "type": "modu
   })
 })
 
-it('should work with .ts config file and `export default` without "type": "module"', async () => {
+it('works with .ts config file and `export default` without "type": "module"', async () => {
   expect(await check('ts-config-file-esm')).toEqual({
     checks: [
       {
@@ -293,7 +293,7 @@ it('should work with .ts config file and `export default` without "type": "modul
   })
 })
 
-it('should work with .ts config file', async () => {
+it('works with .ts config file', async () => {
   expect(await check('ts-config-file')).toEqual({
     checks: [
       {
@@ -307,7 +307,7 @@ it('should work with .ts config file', async () => {
   })
 })
 
-it('should work with .cts config file', async () => {
+it('works with .cts config file', async () => {
   expect(await check('cts-config-file')).toEqual({
     checks: [
       {
@@ -321,7 +321,7 @@ it('should work with .cts config file', async () => {
   })
 })
 
-it('should work with .mts config file', async () => {
+it('works with .mts config file', async () => {
   expect(await check('mts-config-file')).toEqual({
     checks: [
       {
@@ -335,7 +335,7 @@ it('should work with .mts config file', async () => {
   })
 })
 
-it('should work with .ts config file and "type": "module"', async () => {
+it('works with .ts config file and "type": "module"', async () => {
   expect(await check('ts-config-file-with-type-module')).toEqual({
     checks: [
       {
@@ -439,7 +439,7 @@ describe.each(allConfigFileExtensions)(
   'config file with `.%s` extension',
   extension => {
     it.each(exportTypes)(
-      'should work with $moduleType module syntax ($exportSyntax)',
+      'works with $moduleType module syntax ($exportSyntax)',
       async ({ moduleType }) => {
         expect(await check(`${extension}-config-file-${moduleType}`)).toEqual({
           checks: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       globby:
         specifier: ^14.0.1
         version: 14.0.1
+      jiti:
+        specifier: ^1.21.0
+        version: 1.21.0
       lilconfig:
         specifier: ^3.1.1
         version: 3.1.1
@@ -3673,6 +3676,11 @@ packages:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: false
+
+  /jiti@1.21.0:
+    resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
+    hasBin: true
     dev: false
 
   /jora@1.0.0-beta.8:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         'packages/preset-app/index.js'
       ]
     },
-    testTimeout: 20_000,
-    watchExclude: ['**/fixtures', '**/dist', '**/out']
-  }
+    testTimeout: 20_000
+  },
+  server: { watch: { ignored: ['**/fixtures', '**/dist', '**/out'] } }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { coverageConfigDefaults, defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
@@ -11,6 +11,7 @@ export default defineConfig({
       skipFull: true,
       clean: true,
       exclude: [
+        ...coverageConfigDefaults.exclude,
         '**/fixtures',
         '**/scripts',
         '**/test',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,8 @@ export default defineConfig({
         'packages/preset-app/index.js'
       ]
     },
-    testTimeout: 20_000
+    testTimeout: 20_000,
+    retry: process.env.CI ? 1 : 0
   },
   server: { watch: { ignored: ['**/fixtures', '**/dist', '**/out'] } }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
       ]
     },
     testTimeout: 20_000,
-    retry: process.env.CI ? 1 : 0
+    retry: process.env.CI ? 1 : 0,
+    fileParallelism: !process.env.CI
   },
   server: { watch: { ignored: ['**/fixtures', '**/dist', '**/out'] } }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
         'packages/preset-app/index.js'
       ]
     },
-    testTimeout: 10000,
+    testTimeout: 20_000,
     watchExclude: ['**/fixtures', '**/dist', '**/out']
   }
 })


### PR DESCRIPTION
## This PR:

  - [X] Adds [`jiti`](https://github.com/unjs/jiti) as a dependency.
  - [X] Adds support for loading TypeScript config files (`.size-limit.ts`, `.size-limit.mts`, `.size-limit.cts`).
  - [X] Adds fixtures to test every single file extension/module type combo to make sure the library is fully capable of handling different configuration flles.
  - [X] Test performance to make sure we overhead was not accumulated.
  - [X] Adds unit tests to test edge cases.