### PR TITLE
Fix StatoscopeWebpackPlugin import to support default export

### DIFF
--- a/packages/webpack-why/index.js
+++ b/packages/webpack-why/index.js
@@ -6,7 +6,7 @@ function addStatoscope(limitConfig, check, webpackConfig) {
     let shouldOpen = process.env.NODE_ENV !== 'test' && !limitConfig.saveBundle
 
     webpackConfig.plugins.push(
-      new StatoscopeWebpackPlugin({
+      new StatoscopeWebpackPlugin.default({
         additionalStats: [limitConfig.compareWith, check.compareWith].filter(
           Boolean
         ),
@@ -24,7 +24,7 @@ function addStatoscope(limitConfig, check, webpackConfig) {
     )
   } else if (limitConfig.saveBundle) {
     webpackConfig.plugins.push(
-      new StatoscopeWebpackPlugin({
+      new StatoscopeWebpackPlugin.default({
         open: false,
         saveReportTo: join(limitConfig.saveBundle, 'report.html'),
         saveStatsTo: join(limitConfig.saveBundle, 'stats.json'),


### PR DESCRIPTION
- [x] Fixes the `TypeError: StatoscopeWebpackPlugin is not a constructor` error.

An error `TypeError: StatoscopeWebpackPlugin is not a constructor` occurs if the module does not export as default.

@ai Hello, I wanted to bring to your attention an issue I've found while utilizing the `@size-limit/webpack-why` package. Since I got an error message (`StatoscopeWebpackPlugin is not a constructor`), I have consulted with the [official documentation](https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin). They advised that the class should be imported using the default export.

I have submitted a PR addressing this matter and would greatly appreciate it if you could take a moment to review the proposed changes. Your feedback would be invaluable.