### PR TITLE
Support css content in esbuild plugin

### DIFF
--- a/packages/esbuild/index.js
+++ b/packages/esbuild/index.js
@@ -23,18 +23,20 @@ function getFiles(buildResult, check) {
   let outputs = buildResult.metafile.outputs
 
   for (let key in outputs) {
-    let outputEntryName = parse(key).name
+    let outputEntryName = parse(key).base
     outputs[outputEntryName] = outputs[key]
     outputs[outputEntryName].path = resolve(key)
     delete outputs[key]
   }
 
   if (check.entry) {
-    for (let i of check.entry) {
-      if (outputs[i]) {
-        entries[i] = outputs[i]
-      } else {
-        throw new SizeLimitError('unknownEntry', i)
+    for (let entry of check.entry) {
+      let matches = Object.keys(outputs).filter(key => parse(key).name === entry)
+      if(matches.length === 0) {
+        throw new SizeLimitError('unknownEntry', entry)
+      }
+      for(let match of matches) {
+        entries[match] = outputs[match]
       }
     }
   } else {

--- a/packages/esbuild/test/fixtures/esm/nonjs.js
+++ b/packages/esbuild/test/fixtures/esm/nonjs.js
@@ -1,0 +1,2 @@
+import './file.js'
+import './style.css'

--- a/packages/esbuild/test/fixtures/esm/style.css
+++ b/packages/esbuild/test/fixtures/esm/style.css
@@ -1,0 +1,3 @@
+a {
+  color: black
+}

--- a/packages/esbuild/test/index.test.js
+++ b/packages/esbuild/test/index.test.js
@@ -64,6 +64,14 @@ it('uses esbuild to make bundle', async () => {
   expect(existsSync(config.checks[0].esbuildOutfile)).toBe(false)
 })
 
+it('supports bundles with css', async () => {
+  let config = {
+    checks: [{ files: fixture('esm/nonjs.js') }]
+  }
+  await run(config)
+  expect(config.checks[0].size).toBe(49)
+})
+
 it('supports ignore', async () => {
   let config = {
     checks: [{ files: fixture('cjs/big.js'), ignore: ['redux'] }]

--- a/packages/size-limit/size-limit-error.js
+++ b/packages/size-limit/size-limit-error.js
@@ -37,7 +37,7 @@ const MESSAGES = {
   unknownArg: arg =>
     `Unknown argument *${arg}*. Check command for typo and read docs.`,
   unknownEntry: entry =>
-    `Size Limit didn’t find *${entry}* entry in custom Webpack config`,
+    `Size Limit didn’t find *${entry}* entry in the custom bundler config`,
   unknownOption: opt =>
     `Unknown option *${opt}* in config. Check Size Limit docs and version.`
 }

--- a/packages/size-limit/test/__snapshots__/size-limit-error.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/size-limit-error.test.js.snap
@@ -12,7 +12,7 @@ exports[`has error for CLI error without output 1`] = `
 `;
 
 exports[`has error for unknown entry 1`] = `
-"[41m[30m ERROR [39m[49m [31mSize Limit didn’t find [33madmin[31m entry in custom Webpack config[39m
+"[41m[30m ERROR [39m[49m [31mSize Limit didn’t find [33madmin[31m entry in the custom bundler config[39m
 "
 `;
 


### PR DESCRIPTION
`parse('index.css').name` and `parse('index.js').name` prodiuces the same `index` key, which overwrites one of the entries. 

Use `base` to prevent conflicts and use `index.js`/`index.css` as the keys.


Fixes #360

