### PR TITLE
Fix type of `plugins` parameter to be an array of functions

### DIFF
--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -113,7 +113,7 @@ type AnyFunction = (...args: any[]) => any
  * @return Project size
  */
 declare function sizeLimitAPI(
-  plugins: AnyFunction,
+  plugins: AnyFunction[],
   files: string[] | object
 ): Promise<object>
 


### PR DESCRIPTION
## **This PR:**

- [X] Fixes the type of `plugins` parameter of the `sizeLimitAPI` function to be an array of functions instead of a single function.