### PR TITLE
Fix `EPERM` errors on Windows when using the `--save-bundle` and `--clean-dir` CLI arguments

### DIFF
--- a/packages/size-limit/rm.js
+++ b/packages/size-limit/rm.js
@@ -5,9 +5,9 @@ export async function rm(dir) {
   if (!fs.rm) {
     /* c8 ignore next 3 */
     if (existsSync(dir)) {
-      await fs.rmdir(dir, { recursive: true })
+      await fs.rmdir(dir, { maxRetries: 3, recursive: true })
     }
   } else {
-    await fs.rm(dir, { force: true, recursive: true })
+    await fs.rm(dir, { force: true, maxRetries: 3, recursive: true })
   }
 }


### PR DESCRIPTION
## **Overview**

When using the `--save-bundle` and `--clean-dir` CLI arguments, we can get intermittent `EPERM` errors on Windows. My assumption is that there is probably some sort of race condition involved. The issue originates from the `before` function of the `'@size-limit/webpack'` plugin. I'm not sure if there is potential for more errors, I will try and take a closer look later but for now, adding the `maxRetries` option to the `fs.rm` and `fs.rmdir` functions seems to resolve this issue.

## **This PR:**

- [X] Adds the `maxRetries` option to `fs.rm` and `fs.rmdir` functions to mitigate `EPERM` errors on Windows when using the `--save-bundle` and `--clean-dir` CLI arguments.