### PR TITLE
Escape check paths in get-config

### DIFF
--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -1,4 +1,5 @@
 import bytes from 'bytes-iec'
+import fg from 'fast-glob'
 import { globby } from 'globby'
 import { lilconfig } from 'lilconfig'
 import { createRequire } from 'node:module'
@@ -154,7 +155,7 @@ export default async function getConfig(plugins, process, args, pkg) {
       result.config.map(async check => {
         let processed = { ...check }
         if (check.path) {
-          processed.files = await globby(check.path, { cwd: config.cwd })
+          processed.files = await globby(check.path.map(fg.escapePath), { cwd: config.cwd })
         } else if (!check.entry) {
           if (pkg.packageJson.main) {
             processed.files = [


### PR DESCRIPTION
I ran into an issue https://github.com/ai/size-limit/issues/369 where size limit was failing to detect files/paths that had unescaped characters in them. 

I believe this is due to [how size limit is calling globby](https://github.com/ai/size-limit/blob/main/packages/size-limit/get-config.js#L157). [globby](https://www.npmjs.com/package/globby) (more specifically, fast-glob) expects you [to escape your paths before passing them over](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#escapepathpath). [fast-glob even provides a helper for this](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#escapepathpath).

I've added this helper function to `get-config.js` and found success with it locally. I might be missing some larger context, but wanted to file this as a first step. 