### PR TITLE
fix: remove extra blank line in terminal when output is empty

### DIFF
--- a/packages/size-limit/create-reporter.js
+++ b/packages/size-limit/create-reporter.js
@@ -1,5 +1,6 @@
 import bytes from 'bytes-iec'
 import { join } from 'node:path'
+import readline from 'node:readline'
 import pc from 'picocolors'
 
 const { bgGreen, bgRed, black, bold, gray, green, red, yellow } = pc
@@ -42,10 +43,13 @@ function getFixText(prefix, config) {
 
   return prefix
 }
-
 function createHumanReporter(process, isSilentMode = false) {
+  let output = ''
+
   function print(...lines) {
-    process.stdout.write('  ' + lines.join('\n  ') + '\n')
+    let value = '  ' + lines.join('\n  ') + '\n'
+    output += value
+    process.stdout.write(value)
   }
 
   function formatBytes(size) {
@@ -189,6 +193,12 @@ function createHumanReporter(process, isSilentMode = false) {
         let statsFilepath = join(config.saveBundle, 'stats.json')
         print(`Webpack Stats file was saved to ${statsFilepath}`)
         print('You can review it using https://webpack.github.io/analyse')
+      }
+
+      // clean the blank line in silent mode if the output is empty
+      if (isSilentMode && !output.trim()) {
+        readline.moveCursor(process.stdout, 0, -1)
+        readline.clearLine(process.stdout, 0)
       }
     }
   }

--- a/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/create-reporter.test.js.snap
@@ -134,7 +134,7 @@ exports[`renders list of failed checks in silent mode 1`] = `
 
 exports[`renders list of success checks in silent mode 1`] = `
 "  
-"
+[1A[2K"
 `;
 
 exports[`renders result for file with gzip 1`] = `

--- a/packages/size-limit/test/__snapshots__/run.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/run.test.js.snap
@@ -305,7 +305,7 @@ Check out docs for more complicated cases
 
 exports[`shows nothing in silent mode and success check 1`] = `
 "  
-"
+[1A[2K"
 `;
 
 exports[`shows size-limit dependency warning 1`] = `""`;


### PR DESCRIPTION
The simpler solution is to use `process.stdout.moveCursor()` and `process.stdout.clearLine()` directly. However, i[f TTY is not available we can not use those methods](https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000645510/comments/115000530624) and consuming `readline` is a better-supported solution to do that.

Resolves #363