### PR TITLE
Add disablePlugins as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,9 @@ Each section in the config can have these options:
 * **compareWith**: path to `stats.json` from another build to compare
   (when `--why` is using).
 * **uiReports**: custom UI reports list (see [Statoscope docs]).
+* **disablePlugins**: array of plugin names to skip for this check.
+  Useful for selectively disabling bundling or measurement for specific entries.
+  Plugin names can be: `"esbuild"`, `"@size-limit/esbuild"`, or `"size-limit-esbuild"`.
 
 If you use Size Limit to track the size of CSS files, make sure to set
 `webpack: false`. Otherwise, you will get wrong numbers, because webpack

--- a/README.md
+++ b/README.md
@@ -591,9 +591,9 @@ Each section in the config can have these options:
 * **compareWith**: path to `stats.json` from another build to compare
   (when `--why` is using).
 * **uiReports**: custom UI reports list (see [Statoscope docs]).
-* **disablePlugins**: array of plugin names to skip for this check.
-  Useful for selectively disabling bundling or measurement for specific entries.
-  Plugin names can be: `"esbuild"`, `"@size-limit/esbuild"`, or `"size-limit-esbuild"`.
+* **disablePlugins**: npm package names of plugins to skip
+  for this check. For example: `"@size-limit/webpack"`, `"@size-limit/esbuild"`,
+  or `"@size-limit/time"`.
 
 If you use Size Limit to track the size of CSS files, make sure to set
 `webpack: false`. Otherwise, you will get wrong numbers, because webpack

--- a/fixtures/disable-plugins/index.js
+++ b/fixtures/disable-plugins/index.js
@@ -1,0 +1,1 @@
+module.exports = 1

--- a/fixtures/disable-plugins/package.json
+++ b/fixtures/disable-plugins/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "size-limit": [
+    {
+      "path": "index.js",
+      "disablePlugins": ["esbuild"]
+    }
+  ],
+  "devDependencies": {
+    "@size-limit/esbuild": ">= 0.0.0",
+    "@size-limit/file": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/non-string-disable-plugins/.size-limit.js
+++ b/fixtures/non-string-disable-plugins/.size-limit.js
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    "disablePlugins": 1
+  }
+]

--- a/fixtures/non-string-disable-plugins/package.json
+++ b/fixtures/non-string-disable-plugins/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@size-limit/file": ">= 0.0.0",
+    "size-limit": ">= 0.0.0"
+  }
+}

--- a/fixtures/string-disable-plugins/.size-limit.js
+++ b/fixtures/string-disable-plugins/.size-limit.js
@@ -1,0 +1,6 @@
+module.exports = [
+  {
+    "path": "index.js",
+    "disablePlugins": "@size-limit/esbuild"
+  }
+]

--- a/fixtures/string-disable-plugins/index.js
+++ b/fixtures/string-disable-plugins/index.js
@@ -1,0 +1,1 @@
+module.exports = 'test'

--- a/fixtures/string-disable-plugins/package.json
+++ b/fixtures/string-disable-plugins/package.json
@@ -1,11 +1,5 @@
 {
   "private": true,
-  "size-limit": [
-    {
-      "path": "index.js",
-      "disablePlugins": ["@size-limit/esbuild"]
-    }
-  ],
   "devDependencies": {
     "@size-limit/esbuild": ">= 0.0.0",
     "@size-limit/file": ">= 0.0.0",

--- a/packages/size-limit/calc.js
+++ b/packages/size-limit/calc.js
@@ -1,15 +1,6 @@
 function isPluginDisabled(plugin, check) {
   if (!check.disablePlugins) return false
-  let disabled = Array.isArray(check.disablePlugins)
-    ? check.disablePlugins
-    : [check.disablePlugins]
-  return disabled.some(name => {
-    return (
-      plugin.name === name ||
-      plugin.name === `@size-limit/${name}` ||
-      plugin.name === `size-limit-${name}`
-    )
-  })
+  return check.disablePlugins.includes(plugin.name)
 }
 
 export default async function calc(plugins, config, createSpinner) {

--- a/packages/size-limit/calc.js
+++ b/packages/size-limit/calc.js
@@ -1,16 +1,31 @@
+function isPluginDisabled(plugin, check) {
+  if (!check.disablePlugins) return false
+  let disabled = Array.isArray(check.disablePlugins)
+    ? check.disablePlugins
+    : [check.disablePlugins]
+  return disabled.some(name => {
+    return (
+      plugin.name === name ||
+      plugin.name === `@size-limit/${name}` ||
+      plugin.name === `size-limit-${name}`
+    )
+  })
+}
+
 export default async function calc(plugins, config, createSpinner) {
   process.setMaxListeners(config.checks.reduce((a, i) => a + i.files.length, 1))
 
   async function step(number) {
     for (let plugin of plugins.list) {
+      let checks = config.checks.filter(i => !isPluginDisabled(plugin, i))
       let spinner
-      if (plugin['wait' + number] && createSpinner) {
+      if (checks.length > 0 && plugin['wait' + number] && createSpinner) {
         spinner = createSpinner(plugin['wait' + number]).start()
       }
       if (plugin['step' + number]) {
         try {
           await Promise.all(
-            config.checks.map(i => {
+            checks.map(i => {
               return plugin['step' + number](config, i)
             })
           )
@@ -26,8 +41,9 @@ export default async function calc(plugins, config, createSpinner) {
   async function callMethodForEachPlugin(methodName) {
     for (let plugin of plugins.list) {
       if (plugin[methodName]) {
+        let checks = config.checks.filter(i => !isPluginDisabled(plugin, i))
         await Promise.all(
-          config.checks.map(i => {
+          checks.map(i => {
             return plugin[methodName](config, i)
           })
         )

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -44,6 +44,10 @@ function isStringsOrUndefined(value) {
   return type === 'undefined' || type === 'string' || isStrings(value)
 }
 
+function isStringArrayOrUndefined(value) {
+  return typeof value === 'undefined' || isStrings(value)
+}
+
 function endsWithMs(value) {
   return / ?ms/i.test(value)
 }
@@ -69,8 +73,8 @@ function checkChecks(plugins, checks) {
     if (!isStringsOrUndefined(check.entry)) {
       throw new SizeLimitError('entryNotString')
     }
-    if (!isStringsOrUndefined(check.disablePlugins)) {
-      throw new SizeLimitError('disablePluginsNotString')
+    if (!isStringArrayOrUndefined(check.disablePlugins)) {
+      throw new SizeLimitError('disablePluginsNotArray')
     }
     for (let opt in check) {
       let available = OPTIONS[opt]

--- a/packages/size-limit/get-config.js
+++ b/packages/size-limit/get-config.js
@@ -14,6 +14,7 @@ let OPTIONS = {
   compareWith: 'webpack',
   config: ['webpack', 'esbuild'],
   disableModuleConcatenation: 'webpack',
+  disablePlugins: true,
   entry: 'webpack',
   gzip: 'file',
   hidePassed: false,
@@ -67,6 +68,9 @@ function checkChecks(plugins, checks) {
     }
     if (!isStringsOrUndefined(check.entry)) {
       throw new SizeLimitError('entryNotString')
+    }
+    if (!isStringsOrUndefined(check.disablePlugins)) {
+      throw new SizeLimitError('disablePluginsNotString')
     }
     for (let opt in check) {
       let available = OPTIONS[opt]

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -20,11 +20,10 @@ export interface Check {
   disableModuleConcatenation?: boolean
 
   /**
-   * Array of plugin names to skip for this check.
-   * Plugin names can be short (`"esbuild"`), scoped (`"@size-limit/esbuild"`),
-   * or hyphenated (`"size-limit-esbuild"`).
+   * Plugin npm package names to skip for this check.
+   * For example: `["@size-limit/webpack"]`, `["@size-limit/esbuild"]`, or `["@size-limit/time"]`.
    */
-  disablePlugins?: string | string[]
+  disablePlugins?: string[]
 
   /**
    * When using a custom webpack config, a webpack entry could be given.

--- a/packages/size-limit/index.d.ts
+++ b/packages/size-limit/index.d.ts
@@ -20,6 +20,13 @@ export interface Check {
   disableModuleConcatenation?: boolean
 
   /**
+   * Array of plugin names to skip for this check.
+   * Plugin names can be short (`"esbuild"`), scoped (`"@size-limit/esbuild"`),
+   * or hyphenated (`"size-limit-esbuild"`).
+   */
+  disablePlugins?: string | string[]
+
+  /**
    * When using a custom webpack config, a webpack entry could be given.
    * It could be a string or an array of strings. By default,
    * the total size of all entry points will be checked.

--- a/packages/size-limit/size-limit-error.js
+++ b/packages/size-limit/size-limit-error.js
@@ -14,10 +14,10 @@ const MESSAGES = {
     `The directory *${dir}* is not empty. ` +
     'Pass *--clean-dir* if you want to remove it',
   cmdError: (cmd, error) => (error ? `${cmd} error: ${error}` : `${cmd} error`),
-  emptyConfig: () => 'Size Limit config must *not be empty*',
-  disablePluginsNotString: () =>
+  disablePluginsNotArray: () =>
     'The *disablePlugins* in Size Limit config ' +
-    'must be *a string* or *an array of strings*',
+    'must be *an array of strings*',
+  emptyConfig: () => 'Size Limit config must *not be empty*',
   entryNotString: () =>
     'The *entry* in Size Limit config ' +
     'must be *a string* or *an array of strings*',

--- a/packages/size-limit/size-limit-error.js
+++ b/packages/size-limit/size-limit-error.js
@@ -15,6 +15,9 @@ const MESSAGES = {
     'Pass *--clean-dir* if you want to remove it',
   cmdError: (cmd, error) => (error ? `${cmd} error: ${error}` : `${cmd} error`),
   emptyConfig: () => 'Size Limit config must *not be empty*',
+  disablePluginsNotString: () =>
+    'The *disablePlugins* in Size Limit config ' +
+    'must be *a string* or *an array of strings*',
   entryNotString: () =>
     'The *entry* in Size Limit config ' +
     'must be *a string* or *an array of strings*',

--- a/packages/size-limit/test/__snapshots__/run.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/run.test.js.snap
@@ -489,6 +489,11 @@ exports[`throws on non-object check 1`] = `
 "
 `;
 
+exports[`throws on non-string disablePlugins 1`] = `
+"[41m[30m ERROR [39m[49m [31mThe [33mdisablePlugins[31m in Size Limit config must be [33ma string[31m or [33man array of strings[31m[39m
+"
+`;
+
 exports[`throws on non-string entry 1`] = `
 "[41m[30m ERROR [39m[49m [31mThe [33mentry[31m in Size Limit config must be [33ma string[31m or [33man array of strings[31m[39m
 "

--- a/packages/size-limit/test/__snapshots__/run.test.js.snap
+++ b/packages/size-limit/test/__snapshots__/run.test.js.snap
@@ -477,6 +477,11 @@ exports[`throws on non-array config 1`] = `
 "
 `;
 
+exports[`throws on non-array disablePlugins 1`] = `
+"[41m[30m ERROR [39m[49m [31mThe [33mdisablePlugins[31m in Size Limit config must be [33man array of strings[31m[39m
+"
+`;
+
 exports[`throws on non-object check 1`] = `
 "[41m[30m ERROR [39m[49m [31mSize Limit config array should contain [33monly objects[31m[39m
 
@@ -486,11 +491,6 @@ exports[`throws on non-object check 1`] = `
       [32m"limit"[39m: [33m"10 kB"[39m
     }
   ]
-"
-`;
-
-exports[`throws on non-string disablePlugins 1`] = `
-"[41m[30m ERROR [39m[49m [31mThe [33mdisablePlugins[31m in Size Limit config must be [33ma string[31m or [33man array of strings[31m[39m
 "
 `;
 
@@ -513,6 +513,11 @@ exports[`throws on non-string path 1`] = `
 
 exports[`throws on running option without time plugin 1`] = `
 "[41m[30m ERROR [39m[49m [31mConfig option [33mrunning[31m needs [33m@size-limit/time[31m plugin[39m
+"
+`;
+
+exports[`throws on string disablePlugins 1`] = `
+"[41m[30m ERROR [39m[49m [31mThe [33mdisablePlugins[31m in Size Limit config must be [33man array of strings[31m[39m
 "
 `;
 

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -364,6 +364,21 @@ it('uses peerDependencies as ignore option', async () => {
   })
 })
 
+it('supports disablePlugins option', async () => {
+  expect(await check('disable-plugins')).toEqual({
+    checks: [
+      {
+        disablePlugins: ['esbuild'],
+        files: [fixture('disable-plugins', 'index.js')],
+        name: 'index.js',
+        path: 'index.js'
+      }
+    ],
+    configPath: 'package.json',
+    cwd: fixture('disable-plugins')
+  })
+})
+
 it('normalizes time limits', async () => {
   expect(await check('time')).toEqual({
     checks: [

--- a/packages/size-limit/test/get-config.test.js
+++ b/packages/size-limit/test/get-config.test.js
@@ -368,7 +368,7 @@ it('supports disablePlugins option', async () => {
   expect(await check('disable-plugins')).toEqual({
     checks: [
       {
-        disablePlugins: ['esbuild'],
+        disablePlugins: ['@size-limit/esbuild'],
         files: [fixture('disable-plugins', 'index.js')],
         name: 'index.js',
         path: 'index.js'

--- a/packages/size-limit/test/run.test.js
+++ b/packages/size-limit/test/run.test.js
@@ -243,8 +243,12 @@ it('throws on non-string entry', async () => {
   expect(await error('non-string-entry')).toMatchSnapshot()
 })
 
-it('throws on non-string disablePlugins', async () => {
+it('throws on non-array disablePlugins', async () => {
   expect(await error('non-string-disable-plugins')).toMatchSnapshot()
+})
+
+it('throws on string disablePlugins', async () => {
+  expect(await error('string-disable-plugins')).toMatchSnapshot()
 })
 
 it('respects disablePlugins option', async () => {

--- a/packages/size-limit/test/run.test.js
+++ b/packages/size-limit/test/run.test.js
@@ -243,6 +243,19 @@ it('throws on non-string entry', async () => {
   expect(await error('non-string-entry')).toMatchSnapshot()
 })
 
+it('throws on non-string disablePlugins', async () => {
+  expect(await error('non-string-disable-plugins')).toMatchSnapshot()
+})
+
+it('respects disablePlugins option', async () => {
+  await checkJson('disable-plugins', [
+    {
+      name: 'index.js',
+      size: 20
+    }
+  ])
+})
+
 it('throws on webpack option without webpack plugin', async () => {
   expect(await error('non-webpack')).toMatchSnapshot()
   expect(await error('non-webpack-ignore')).toMatchSnapshot()


### PR DESCRIPTION
closes #396 

This adds the option `disablePlugins`. The benefit of doing this is to still have multiple plugins installed, but disable plugins per entry of the array. The usage could look like this:

```js

modue.exports = [
  // following disables the `esbuild` plugin
  {
    name: 'first-package',
    disablePlugins: ['esbuild'],
  },
  // following disables the `webpack` plugin
  {
    name: 'second-package',
    disablePlugins: ['webpack'],
  },
];
```

I do wonder now if it would make sense to deprecate the `webpack: boolean` option in favor of `disablePlugins`, as `disablePlugins: ['webpack']` would do the same now